### PR TITLE
Add External Immich URL Redirection via Environment Variable

### DIFF
--- a/src/components/people/PersonItem.tsx
+++ b/src/components/people/PersonItem.tsx
@@ -18,7 +18,7 @@ interface IProps {
   onRemove: (person: IPerson) => void;
 }
 export default function PersonItem({ person, onRemove }: IProps) {
-  const { immichURL } = useConfig();
+  const { exImmichUrl } = useConfig();
   const { toast } = useToast();
   const [editMode, setEditMode] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -98,7 +98,7 @@ export default function PersonItem({ person, onRemove }: IProps) {
         <div className="absolute top-2 left-2 group-hover:block hidden">
           <Link
             className="bg-green-300 block rounded-lg px-2 py-1 text-sm dark:text-gray-900"
-            href={`${immichURL}/people/${person.id}`}
+            href={`${exImmichUrl}/people/${person.id}`}
             target="_blank"
           >
             <ArrowUpRight size={16} />

--- a/src/components/shared/ProfileInfo.tsx
+++ b/src/components/shared/ProfileInfo.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useConfig } from "@/contexts/ConfigContext";
 
 export default function ProfileInfo() {
-  const { immichURL } = useConfig();
+  const { immichURL,exImmichUrl } = useConfig();
   const [user, setUser] = React.useState<IUser | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -30,7 +30,11 @@ export default function ProfileInfo() {
   return (
     <>
       <div className="flex flex-col gap-2 text-xs text-center py-2">
-        <p className="text-muted-foreground font-mono">Connected to</p>
+        <p className="text-muted-foreground font-mono">Connected to (External)</p>
+        <Link href={exImmichUrl} target="_blank" className="font-mono">
+          {exImmichUrl}
+        </Link>
+        <p className="text-muted-foreground font-mono">Connected to (Internal)</p>
         <Link href={immichURL} target="_blank" className="font-mono">
           {immichURL}
         </Link>

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -1,5 +1,6 @@
 export const ENV = {
   IMMICH_URL: (process.env.IMMICH_URL || 'http://immich_server:3001') as string,
+  EXTERNAL_IMMICH_URL: (process.env.EXTERNAL_IMMICH_URL || process.env.IMMICH_URL) as string,
   IMMICH_API_KEY: process.env.IMMICH_API_KEY as string,
   DATABASE_URL: (process.env.DATABASE_URL || `postgresql://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${(process.env.DB_HOST || 'immich_postgres')}:${(process.env.DB_PORT || '5432')}/${process.env.DB_DATABASE_NAME}`),
 };

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -2,10 +2,12 @@ import { createContext, useContext } from "react";
 
 interface ConfigContextType {
   immichURL: string;
+  exImmichUrl: string;
 }
 
 const ConfigContext = createContext<ConfigContextType>({
   immichURL: "",
+  exImmichUrl: "",
 });
 
 export default ConfigContext;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,6 +10,7 @@ import { getMe } from "@/handlers/api/user.handler";
 interface AppPropsWithProps extends AppProps {
   props: {
     immichURL: string;
+    exImmichUrl: string;
   };
 }
 const App = ({ Component, pageProps, ...props }: AppPropsWithProps) => {
@@ -29,6 +30,7 @@ const App = ({ Component, pageProps, ...props }: AppPropsWithProps) => {
 App.getInitialProps = async () => {
   return {
     props: {
+      exImmichUrl: ENV.EXTERNAL_IMMICH_URL,
       immichURL: ENV.IMMICH_URL,
     },
   };


### PR DESCRIPTION
- Added a new environment variable `EXTERNAL_IMMICH_URL` to handle redirection to an external Immich URL when provided, instead of using the internal link. This ensures proper routing for external access.