### PR TITLE
feat: added secure cookie env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,6 @@ DB_PASSWORD="" # Postgres Database Password
 DB_HOST="" # Postgres Host (IP address or hostname of the database)
 DB_PORT="" # Postgres Port number (Default: 5432)
 DB_DATABASE_NAME="" # Name of the database 
+
+# Additional configuration
+SECURE_COOKIE=false # Set to true to enable secure cookies

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ IMMICH_URL = "http://local-ip-of-immich:port" # Your immich instace ip address a
 EXTERNAL_IMMICH_URL = "https://external-address" # External address of immich
 ```
 Refer here for obtaining Immich API Key: https://immich.app/docs/features/command-line-interface#obtain-the-api-key
+
 #### Method 2 - Portainer
 
 If you're using portainer, run the docker using `docker run` and add the power tools to the same network as immich.

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -4,6 +4,7 @@ export const ENV = {
   IMMICH_API_KEY: process.env.IMMICH_API_KEY as string,
   DATABASE_URL: (process.env.DATABASE_URL || `postgresql://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${(process.env.DB_HOST || 'immich_postgres')}:${(process.env.DB_PORT || '5432')}/${process.env.DB_DATABASE_NAME}`),
   JWT_SECRET: process.env.JWT_SECRET as string,
+  SECURE_COOKIE: process.env.SECURE_COOKIE === 'true',
 };
 
 

--- a/src/lib/cookie.ts
+++ b/src/lib/cookie.ts
@@ -1,3 +1,4 @@
+import { ENV } from '@/config/environment'
 import type { CookieSerializeOptions } from 'cookie'
 import cookie from 'cookie'
 import type { IncomingMessage } from 'http'
@@ -22,8 +23,7 @@ export const serializeCookie = (
   return cookie.serialize(name, String(value), {
     httpOnly: true,
     maxAge: 60 * 60 * 24 * 7,
-    sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
-    secure: process.env.NODE_ENV === 'production',
+    secure: ENV.SECURE_COOKIE,
     path: '/',
     ...options,
   })


### PR DESCRIPTION
Since people use IMMICH via HTTPS or HTTP, I made the cookie `secure` policy to be set via ENV 

Use `SECURE_COOKIE` to use secure cookie policy (when you use HTTPS)