### PR TITLE
Fixed date list for missing location scenario 

### DIFF
--- a/src/pages/api/assets/missing-location-dates.ts
+++ b/src/pages/api/assets/missing-location-dates.ts
@@ -31,7 +31,6 @@ export default async function handler(
         isNull(exif.latitude),
         isNotNull(assets.createdAt),
         isNotNull(exif.dateTimeOriginal),
-        eq(assets.type, "VIDEO"),
         eq(assets.ownerId, currentUser.id),
         eq(assets.isVisible, true),
       ))


### PR DESCRIPTION
There was an extra filter for just VIDEO assets, which caused the list to behave weirdly..

Removing the filter fixed it.