### PR TITLE
If one element is already selected - make it easier to select more

### DIFF
--- a/src/components/assets/missing-location/MissingLocationAssets.tsx
+++ b/src/components/assets/missing-location/MissingLocationAssets.tsx
@@ -81,7 +81,15 @@ export default function MissingLocationAssets({ groupBy }: IProps) {
     [images]
   );
 
-  const handleClick = (idx: number) => setIndex(idx);
+  const handleClick = (idx: number, asset: IAsset, event: MouseEvent<HTMLElement>) => {
+    if (selectedIds.length > 0) {
+      handleSelect(idx, asset, event);
+    }
+    else
+    {
+      setIndex(idx);
+    }
+  };
 
   const handleSelect = (_idx: number, asset: IAsset, event: MouseEvent<HTMLElement>) => {
     event.stopPropagation();


### PR DESCRIPTION
This is similar to the behavior that OneDrive, dropbox, .. and others are having..

If ONE element is selected in the list, the "selection" mode is enabled - making additional selections easier.
(it's really hard to hit the left top corner on phones and tablets.., hence "selection mode" is great)

I've been using this in a private version and I'm finding it a productivity booster on phone and tablet.

Let me know what you think @varun-raj !