### PR TITLE
fix: width styling of tag missing location dialog recent searches

### DIFF
--- a/src/components/assets/missing-location/TagMissingLocationDialog/RecentSearches.tsx
+++ b/src/components/assets/missing-location/TagMissingLocationDialog/RecentSearches.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { getRecentSearchesByType, RecentSearch } from "@/lib/utils";
+import { getRecentSearchesByType, RecentSearch, cn } from "@/lib/utils";
 import { IPlace } from "@/types/common";
 import { Clock, MapPin } from "lucide-react";
 import React from "react";
@@ -9,9 +8,10 @@ interface RecentSearchesProps {
   searchType: RecentSearch['searchType'];
   onSelect: (place: IPlace) => void;
   selectedPlace?: IPlace | null;
+  className?: string;
 }
 
-export default function RecentSearches({ searchType, onSelect, selectedPlace }: RecentSearchesProps) {
+export default function RecentSearches({ searchType, onSelect, selectedPlace, className }: RecentSearchesProps) {
   const recentSearches = getRecentSearchesByType(searchType);
 
   if (recentSearches.length === 0) {
@@ -32,7 +32,7 @@ export default function RecentSearches({ searchType, onSelect, selectedPlace }: 
   };
 
   return (
-    <div className="mb-4">
+    <div className={cn("mb-4", className)}>
       <div className="flex items-center gap-2 mb-3">
         <Clock className="h-4 w-4 text-muted-foreground" />
         <h3 className="text-sm font-medium text-muted-foreground">Recent Searches</h3>
@@ -50,7 +50,7 @@ export default function RecentSearches({ searchType, onSelect, selectedPlace }: 
               "hover:bg-zinc-200 dark:hover:bg-zinc-800 flex justify-between items-center px-3 py-2 rounded-lg cursor-pointer border",
               {
                 "bg-zinc-200 dark:bg-zinc-800 border-primary":
-                  selectedPlace && 
+                  selectedPlace &&
                   selectedPlace.name === search.name &&
                   selectedPlace.latitude === search.latitude &&
                   selectedPlace.longitude === search.longitude,
@@ -60,7 +60,7 @@ export default function RecentSearches({ searchType, onSelect, selectedPlace }: 
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2">
                 <MapPin className="h-3 w-3 text-muted-foreground flex-shrink-0" />
-                <p className="text-sm truncate">{search.name}</p>
+                <p className="text-sm line-clamp-2">{search.name}</p>
               </div>
               <div className="flex items-center justify-between mt-1">
                 <span className="text-xs text-muted-foreground">
@@ -76,4 +76,4 @@ export default function RecentSearches({ searchType, onSelect, selectedPlace }: 
       </div>
     </div>
   );
-} 
+}

--- a/src/components/assets/missing-location/TagMissingLocationDialog/TagMissingLocationDialog.tsx
+++ b/src/components/assets/missing-location/TagMissingLocationDialog/TagMissingLocationDialog.tsx
@@ -54,7 +54,7 @@ export default function TagMissingLocationDialog({
             Tagging a location will add the location to the selected {selectedIds.length} asset(s).
           </DialogDescription>
         </DialogHeader>
-        <Tabs defaultValue="searchOsm" className="border rounded-lg">
+        <Tabs defaultValue="searchOsm" className="border rounded-lg min-w-0 max-w-full">
           <TabsList className="flex justify-between">
             <TabsTrigger value="searchOsm" className="w-full">Open Street Map</TabsTrigger>
             <TabsTrigger value="search" className="w-full">Immich Geo</TabsTrigger>
@@ -71,16 +71,17 @@ export default function TagMissingLocationDialog({
             <TagMissingLocationSearchLatLong onSubmit={onSubmit} onOpenChange={setOpen} location={mapPosition} onLocationChange={setMapPosition} />
           </TabsContent>
           <TabsContent value="maps">
-            <div className="flex flex-col gap-6 items-center ">
+            <div className="flex flex-col gap-6 items-center min-w-0 max-w-full py-4">
               {/* Recent Searches */}
-              <RecentSearches 
-                searchType="map" 
+              <RecentSearches
+                searchType="map"
                 onSelect={(place) => {
                   setMapPosition(place);
                 }}
                 selectedPlace={mapPosition.name ? mapPosition : null}
+                className="w-[500px]" // Matching the width of the map
               />
-              
+
               <LazyMap location={{
                 latitude: isNaN(mapPosition.latitude) ? 0 : mapPosition.latitude,
                 longitude: isNaN(mapPosition.longitude) ? 0 : mapPosition.longitude,


### PR DESCRIPTION
Noticed that long location names broke the styling on the tag missing location dialog. This fixes that and also allows the location name to be displayed on two lines as (at least so far I've seen) most times the location names are pretty long.

Before:
<img width="758" height="426" alt="image" src="https://github.com/user-attachments/assets/e9d791db-b9cb-4895-afa5-958bfc47f7c6" />

<img width="693" height="836" alt="image" src="https://github.com/user-attachments/assets/7898141a-4adb-4a4a-8991-178da43799a7" />

After:
<img width="612" height="449" alt="image" src="https://github.com/user-attachments/assets/f8d7377e-0b84-4754-892d-f8d03436dca3" />

<img width="611" height="882" alt="image" src="https://github.com/user-attachments/assets/518c41cc-b38c-4ff4-a1fe-274601ed47e9" />

<img width="522" height="119" alt="image" src="https://github.com/user-attachments/assets/4fcdba9f-cb67-4c3f-80d9-857532245d0d" />
