### PR TITLE
Refactor environment variables to read from files

### DIFF
--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -1,10 +1,25 @@
+import { readFileSync } from 'fs';
+
+function readEnvOrFile(envVar: string | undefined, fileEnvVar: string | undefined): string | undefined {
+  if (fileEnvVar) {
+    try {
+      return readFileSync(fileEnvVar, 'utf8').trim();
+    } catch (error) {
+      console.error(`Error reading secret from file ${fileEnvVar}:`, error);
+      throw error;
+    }
+  }
+
+  return envVar;
+}
+
 export const ENV = {
   IMMICH_URL: (process.env.IMMICH_URL || 'http://immich_server:2283') as string,
   EXTERNAL_IMMICH_URL: (process.env.EXTERNAL_IMMICH_URL || process.env.IMMICH_URL) as string,
-  IMMICH_API_KEY: process.env.IMMICH_API_KEY as string,
+  IMMICH_API_KEY: readEnvOrFile(process.env.IMMICH_API_KEY, process.env.IMMICH_API_KEY_FILE) as string,
   DATABASE_URL: process.env.DATABASE_URL as string,
   DB_USERNAME: process.env.DB_USERNAME as string,
-  DB_PASSWORD: process.env.DB_PASSWORD as string,
+  DB_PASSWORD: readEnvOrFile(process.env.DB_PASSWORD, process.env.DB_PASSWORD_FILE) as string,
   DB_HOST: process.env.DB_HOST as string,
   DB_PORT: process.env.DB_PORT as string,
   DB_DATABASE_NAME: process.env.DB_DATABASE_NAME as string,
@@ -16,5 +31,3 @@ export const ENV = {
   IMMICH_SHARE_LINK_KEY: process.env.IMMICH_SHARE_LINK_KEY as string,
   POWER_TOOLS_ENDPOINT_URL: process.env.POWER_TOOLS_ENDPOINT_URL as string,
 };
-
-


### PR DESCRIPTION
Reference to Docker docs: https://docs.docker.com/compose/how-tos/use-secrets/#:~:text=The%20_FILE%20environment%20variables%20demonstrated%20here%20are%20a%20convention%20used%20by%20some%20images%2C%20including%20Docker%20Official%20Images%20like%20mysql%20and%20postgres.

This pattern is also used in immich itself: https://docs.immich.app/install/environment-variables#secrets