### PR TITLE
feat: show file path in duplicate finder

### DIFF
--- a/src/components/assets/duplicate-assets/DuplicateAssetRecord.tsx
+++ b/src/components/assets/duplicate-assets/DuplicateAssetRecord.tsx
@@ -100,7 +100,10 @@ function DuplicateAssetItem({ asset, isSelected, onSelect, selectionMode }: Dupl
         <h3 className={`text-sm font-semibold truncate ${isSelected ? 'text-white' : ''}`}>
           {asset.originalFileName}
         </h3>
-        
+        <p className={`text-xs truncate ${isSelected ? 'text-white/70' : 'text-gray-500 dark:text-gray-500'}`} title={asset.originalPath}>
+          {asset.originalPath.substring(0, asset.originalPath.lastIndexOf('/'))}
+        </p>
+
         <div className="mt-2 space-y-1">
           <div className={`flex items-center gap-1 text-xs ${isSelected ? 'text-white' : 'text-gray-600 dark:text-gray-400'}`}>
             <HardDrive size={12} />


### PR DESCRIPTION
Display the directory path below the filename on each duplicate asset card, making it easier to distinguish duplicates with identical names.

Fixes #195
Partially addresses #179 

<img width="1184" height="460" alt="Screenshot_20260228_153524" src="https://github.com/user-attachments/assets/4a895867-e9e9-45b6-80eb-b88a48b4dce2" />
