### PR TITLE
fix: remove encodedVideoPath column removed in latest Immich

### DIFF
--- a/src/pages/api/albums/[id]/assets.ts
+++ b/src/pages/api/albums/[id]/assets.ts
@@ -3,7 +3,7 @@ import { NextApiRequest } from "next";
 import { db } from "@/config/db";
 import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
 import { NextApiResponse } from "next";
-import { and, desc, eq, isNotNull } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { assets } from "@/schema/assets.schema";
 import { albumsAssetsAssets } from "@/schema/albumAssetsAssets.schema";
 import { assetFaces, exif, person } from "@/schema";
@@ -34,9 +34,7 @@ export default async function handler(
     originalPath: assets.originalPath,
     isFavorite: assets.isFavorite,
     duration: assets.duration,
-    encodedVideoPath: assets.encodedVideoPath,
     originalFileName: assets.originalFileName,
-    
     deletedAt: assets.deletedAt,
     localDateTime: assets.localDateTime,
     exifImageWidth: exif.exifImageWidth,

--- a/src/pages/api/albums/potential-albums-assets.ts
+++ b/src/pages/api/albums/potential-albums-assets.ts
@@ -14,7 +14,6 @@ const SELECT_ORPHAN_PHOTOS = (date: string, ownerId:  string) =>
       a."originalPath",
       a."isFavorite",
       a."duration",
-      a."encodedVideoPath",
       a."originalFileName",
       
       a."thumbhash",

--- a/src/pages/api/assets/empty-videos.ts
+++ b/src/pages/api/assets/empty-videos.ts
@@ -56,9 +56,7 @@ const dbAssets = await db
     originalPath: assets.originalPath,
     isFavorite: assets.isFavorite,
     duration: assets.duration,
-    encodedVideoPath: assets.encodedVideoPath,
     originalFileName: assets.originalFileName,
-    
     deletedAt: assets.deletedAt,
     localDateTime: assets.localDateTime,
     exifImageWidth: exif.exifImageWidth,

--- a/src/pages/api/assets/missing-location-assets.ts
+++ b/src/pages/api/assets/missing-location-assets.ts
@@ -8,7 +8,7 @@ import { albumsAssetsAssets } from "@/schema/albumAssetsAssets.schema";
 import { albums } from "@/schema/albums.schema";
 import { IUser } from "@/types/user";
 import { addDays } from "date-fns";
-import { and, eq, gte, isNotNull, isNull, lte, ne, sql } from "drizzle-orm";
+import { and, eq, gte, isNotNull, isNull, lte } from "drizzle-orm";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const getRowsByDates = async (startDateDate: Date, endDateDate: Date, currentUser: IUser) => {
@@ -20,7 +20,6 @@ const getRowsByDates = async (startDateDate: Date, endDateDate: Date, currentUse
       originalPath: assets.originalPath,
       isFavorite: assets.isFavorite,
       duration: assets.duration,
-      encodedVideoPath: assets.encodedVideoPath,
       originalFileName: assets.originalFileName,
       deletedAt: assets.deletedAt,
       localDateTime: assets.localDateTime,
@@ -52,7 +51,6 @@ const getRowsByAlbums = async (currentUser: IUser, albumId: string) => {
     originalPath: assets.originalPath,
     isFavorite: assets.isFavorite,
     duration: assets.duration,
-    encodedVideoPath: assets.encodedVideoPath,
     originalFileName: assets.originalFileName,
     deletedAt: assets.deletedAt,
     localDateTime: assets.localDateTime,
@@ -81,9 +79,8 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const { startDate, groupBy, albumId } = req.query as {
+  const { startDate, albumId } = req.query as {
     startDate: string;
-    groupBy: "date" | "album";
     albumId?: string;
   };
 

--- a/src/pages/api/share-link/[token]/assets.ts
+++ b/src/pages/api/share-link/[token]/assets.ts
@@ -1,7 +1,7 @@
 import { db } from "@/config/db";
 import { ENV } from "@/config/environment";
-import { desc, gte, lte, sql } from "drizzle-orm";
-import { eq, inArray, or, isNull, count } from "drizzle-orm";
+import { desc, gte, lte } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { assetFaces, assets, exif } from "@/schema";
 import { and } from "drizzle-orm";
 import { JsonWebTokenError, sign, verify } from "jsonwebtoken";
@@ -61,7 +61,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       originalPath: assets.originalPath,
       isFavorite: assets.isFavorite,
       duration: assets.duration,
-      encodedVideoPath: assets.encodedVideoPath,
       originalFileName: assets.originalFileName,
       deletedAt: assets.deletedAt,
       localDateTime: assets.localDateTime,

--- a/src/schema/assets.schema.ts
+++ b/src/schema/assets.schema.ts
@@ -11,7 +11,6 @@ export const assets = pgTable('asset', {
   fileModifiedAt: timestamp('fileModifiedAt', { withTimezone: true }).notNull(),
   isFavorite: boolean('isFavorite').default(false).notNull(),
   duration: varchar('duration'),
-  encodedVideoPath: varchar('encodedVideoPath').default(''),
   // checksum: bytea('checksum').notNull(),
   visibility: varchar('visibility').default('timeline').notNull(),
   livePhotoVideoId: uuid('livePhotoVideoId').references((): any => assets.id, { onDelete: 'set null', onUpdate: 'cascade' }),

--- a/src/types/asset.d.ts
+++ b/src/types/asset.d.ts
@@ -6,7 +6,6 @@ export interface IAsset {
   originalPath: string;
   isFavorite: boolean;
   duration: number | null;
-  encodedVideoPath: string | null;
   originalFileName: string;
   thumbhash?: IAssetThumbhash;
   localDateTime: string | Date;


### PR DESCRIPTION
The encodedVideoPath column was removed from Immich's asset table , causing all asset queries to fail with a "column does not exist" error. Fixes #241.