### PR TITLE
Updates power-tools image path referenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you're using portainer, run the docker using `docker run` and add the power t
 
 ```bash
 # Run the power tools from docker 
-docker run -d --name immich_power_tools -p 8001:3000 --env-file .env ghcr.io/varun-raj/immich-power-tools:latest
+docker run -d --name immich_power_tools -p 8001:3000 --env-file .env ghcr.io/immich-power-tools/immich-power-tools:latest
 
 # Add Power tools to the same network as immich
 docker network connect immich_default immich_power_tools

--- a/docker-compose-all-immich.yml
+++ b/docker-compose-all-immich.yml
@@ -73,7 +73,7 @@ services:
       disable: false
   power-tools:
     container_name: immich_power_tools
-    image: ghcr.io/varun-raj/immich-power-tools:latest
+    image: ghcr.io/immich-power-tools/immich-power-tools:latest
     ports:
       - "8001:3000"
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   immich_power_tools:
     container_name: immich_power_tools
-    image: ghcr.io/varun-raj/immich-power-tools:latest
+    image: ghcr.io/immich-power-tools/immich-power-tools:latest
     ports:
       - "3000:3000"
     env_file:


### PR DESCRIPTION
This updates the container image path used as reference to reflect the updated immich-power-tools repository. No other configuration changes were made. 

Some files were still referencing the old image path `ghcr.io/varun-raj/immich-power-tools:latest`. I updated them to `ghcr.io/immich-power-tools/immich-power-tools:latest` in the relevant project files (README.md, docker-compose.yml, and docker-compose-all-immich.yml).