### PR TITLE
fix(find): use getUserHeaders() for Immich smart search auth

### DIFF
--- a/src/pages/api/find/search.ts
+++ b/src/pages/api/find/search.ts
@@ -4,6 +4,7 @@ import { ASSET_VIDEO_PATH } from "@/config/routes";
 import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
 import { cleanUpAsset, isFlipped } from "@/helpers/asset.helper";
 import { parseFindQuery } from "@/helpers/ai.helper";
+import { getUserHeaders } from "@/helpers/user.helper";
 import { person } from "@/schema";
 import { Person } from "@/schema/person.schema";
 import { inArray } from "drizzle-orm";
@@ -16,6 +17,9 @@ export default async function search(
   try {
     const { query } = req.body;
     const currentUser = await getCurrentUser(req);
+    if (!currentUser) {
+      return res.status(403).json({ message: "Not authenticated" });
+    }
     const parsedQuery = await parseFindQuery(query as string);
     const { personIds } = parsedQuery;
 
@@ -32,10 +36,7 @@ export default async function search(
     return fetch(url, {
       method: "POST",
       body: JSON.stringify({ ...parsedQuery, withExif: true }),
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${currentUser?.accessToken}`,
-      },
+      headers: getUserHeaders(currentUser, { "Content-Type": "application/json" }),
     })
       .then((response) => {
         if (response.status !== 200) {


### PR DESCRIPTION
## Summary

The `/api/find/search` handler hard-codes `Authorization: Bearer ${currentUser?.accessToken}`. When Power Tools authenticates via `IMMICH_API_KEY` (no cookie session), `accessToken` is `undefined`, so the request to Immich's `/api/search/smart` arrives as `Bearer undefined`, Immich returns 401, and the UI silently shows **"No results found"** for every query — effectively breaking Find for API-key deployments.

This PR swaps the inline header construction for the existing `getUserHeaders()` helper in `src/helpers/user.helper.ts`, which already handles both auth modes (`x-api-key` when `isUsingAPIKey`, `Authorization: Bearer …` otherwise). It also adds an early `403` when there's no authenticated user rather than letting the request flow forward with `Bearer undefined`.

## Repro

Env (API-key mode):
```
IMMICH_URL=http://immich_server:2283
IMMICH_API_KEY=<your key>
```

Before:
```
$ curl -X POST http://localhost:8001/api/find/search -d '{"query":"beach"}'
{"assets":[],"filters":{…},"error":"Failed to fetch assets"}
```
Immich direct call with identical payload returns 40 matching assets.

After this patch:
```
$ curl -X POST http://localhost:8001/api/find/search -d '{"query":"beach"}'
{"assets":{"count":40,…}}
```

## Test plan

- [x] Verified Find returns results in API-key mode (macOS + Ollama + Immich)
- [ ] Verified Find still works in cookie/session auth mode (would appreciate a second pair of eyes)
- [ ] Unit test for `search` handler with both auth modes

## Related issues

- #240 ("AI search not working") — the "no results returned" symptom matches this exactly; confirmed reproducible in API-key deployments regardless of model (qwen3-8b, qwen3.5-9b, llama3.1) because the request never actually reaches Immich
- #218 — the React 19 + \`react-mentions\` crash is the remaining blocker for the Find UI as a whole; needs a library migration, separate comment there

## Notes

- Part 1 of 2 fixes for Find. #264 is the sibling addressing AI prompt hallucinating \`takenAfter: <today>\` when the query has no date.