### PR TITLE
fix(find): drop hallucinated future-date filters from AI output

### DIFF
--- a/src/helpers/ai.helper.ts
+++ b/src/helpers/ai.helper.ts
@@ -67,10 +67,11 @@ const getOpenAICompatibleModel = () => {
 };
 
 export const parseFindQuery = async (query: string): Promise<FindQuery> => {
+  const today = new Date().toISOString().split("T")[0];
   const prompt = [
     `Parse the following query and return extracted filters as JSON: ${query}.`,
     "Do not include any information that is not intentionally provided in the query.",
-    `Today's date is ${new Date().toISOString().split("T")[0]}.`,
+    `Today's date is ${today}. Use it ONLY to resolve relative expressions like "last week" or "yesterday" that APPEAR IN THE QUERY. If no date-related word is in the query, DO NOT return takenAfter or takenBefore.`,
     "Dates must be in YYYY-MM-DD format.",
     "Return ONLY valid JSON object with keys: query, personIds, city, country, state, size, model, takenAfter, takenBefore, type.",
     "Do not use null values. Omit a key when it is not present in the query.",
@@ -81,10 +82,9 @@ export const parseFindQuery = async (query: string): Promise<FindQuery> => {
     model: getOpenAICompatibleModel(),
     prompt,
     output: Output.object({
-      name:"json",
+      name: "json",
       schema: responseSchema,
     }),
-    
   });
 
   const parsedResponse = JSON.parse(text) as FindQuery;
@@ -94,9 +94,18 @@ export const parseFindQuery = async (query: string): Promise<FindQuery> => {
       delete parsedResponse.type;
     }
   }
-  const cleanedResponse = {
-    ...parsedResponse
-  };
 
-  return removeNullOrUndefinedProperties(cleanedResponse) as any as FindQuery;
+  // Guardrail against a common LLM failure mode: small-to-medium models
+  // (qwen2.5:7b, Gemini flash, etc.) often echo the prompt's "today" date as
+  // `takenAfter` even when the query has no date. A date in the future can
+  // never match a photo, so drop any takenAfter/takenBefore that is today or
+  // later — this keeps the filter purely corrective without guessing intent.
+  if (parsedResponse.takenAfter && parsedResponse.takenAfter >= today) {
+    delete parsedResponse.takenAfter;
+  }
+  if (parsedResponse.takenBefore && parsedResponse.takenBefore > today) {
+    delete parsedResponse.takenBefore;
+  }
+
+  return removeNullOrUndefinedProperties(parsedResponse) as any as FindQuery;
 };


### PR DESCRIPTION
## Summary

When a user searches for something like `beach` on Find, the AI frequently returns `takenAfter: <today>` even though the query has no date reference at all. That filter silently eliminates every match (photos can't be taken in the future), and the UI shows *"No results found / Taken After 2026-04-19"* — same symptom reported in #240 with qwen3-8b / qwen3.5-9b / llama3.1 and in #218 with Gemini 2.0 flash.

Two small changes:

**1. Tighter prompt.** The current prompt tells the model today's date right after saying *"Do not include any information that is not intentionally provided in the query"*. Small/medium LLMs often resolve that contradiction by echoing today back. This patch makes the instruction explicit: *use today only to resolve relative expressions that appear in the query; otherwise do NOT return `takenAfter`/`takenBefore`*.

**2. Guardrail.** If the model still returns a date filter in the future (`takenAfter >= today` or `takenBefore > today`), drop it. This is narrow and defensible:

- A future date literally cannot match any asset, so removing it never loses a valid result.
- No locale-specific regex, no guessing user intent — just rejecting provably invalid filters.
- Larger models (Claude, GPT-4) already follow the tightened prompt; they don't emit these values, so the guardrail is a no-op for them.

## Repro (qwen2.5:7b via Ollama OpenAI-compat endpoint)

Prompt exactly as `parseFindQuery` builds it today:
```
Parse the following query and return extracted filters as JSON: beach.
Do not include any information that is not intentionally provided in the query.
Today's date is 2026-04-19.
Dates must be in YYYY-MM-DD format.
Return ONLY valid JSON object with keys: query, personIds, city, country, state, size, model, takenAfter, takenBefore, type.
Do not use null values. Omit a key when it is not present in the query.
Use type values only IMAGE, VIDEO, AUDIO when possible.
```
Response:
```json
{"query":"beach","takenAfter":"2026-04-19"}
```

With this patch the spurious `takenAfter` never reaches Immich.

## Test plan

- [x] Manual: `"beach"` → filters don't include `takenAfter`, Immich returns matching assets
- [x] Manual: `"photos from august 2022"` → filters include `takenAfter: 2022-08-01` / `takenBefore: 2022-08-31` (past dates preserved, rightly)
- [ ] Unit test covering both paths

## Related issues

- #240 ("AI search not working") — multiple users reporting same symptom across qwen3 variants and llama3.1; the AI output in their logs (`takenAfter: 2026-03-15`) is the exact pattern this PR guards against
- #218 — Gemini 2.0 flash exhibits the same hallucination pattern

## Notes

- Sibling of #263 (auth-headers fix). Both together get Find back to working on API-key deployments with small models.