### PR TITLE
fix(settings): sync Workflow API key required permissions across UI, validator, generator

### DIFF
--- a/src/lib/workflow/permissions.ts
+++ b/src/lib/workflow/permissions.ts
@@ -1,0 +1,26 @@
+/**
+ * Single source of truth for the Immich API-key permissions that the
+ * Power Tools Workflow feature needs.
+ *
+ * `user.read` is required because the validator first calls `/api/users/me`
+ * to verify the key can authenticate at all — without it the check fails
+ * before any resource-level permission is even tested.
+ *
+ * `album.read` is required because the generator creates keys with it, the
+ * validator tests against /api/albums (which needs it), and Power Tools
+ * actions read existing albums when deciding what to update.
+ *
+ * Keep this list in sync with:
+ *   - src/pages/api/settings/validate-api-key.ts  (REQUIRED_PERMISSIONS)
+ *   - src/pages/api/settings/generate-workflow-api-key.ts (WORKFLOW_PERMISSIONS)
+ *   - src/pages/settings/index.tsx  (UI badges)
+ */
+export const WORKFLOW_API_KEY_PERMISSIONS = [
+  "user.read",
+  "asset.read",
+  "asset.update",
+  "album.read",
+  "album.create",
+  "album.update",
+  "tag.create",
+] as const;

--- a/src/pages/api/settings/generate-workflow-api-key.ts
+++ b/src/pages/api/settings/generate-workflow-api-key.ts
@@ -3,19 +3,13 @@ import { appDb } from "@/db";
 import { settings } from "@/db/schema/settings.schema";
 import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
 import { getUserHeaders } from "@/helpers/user.helper";
+import { WORKFLOW_API_KEY_PERMISSIONS } from "@/lib/workflow/permissions";
 import { and, eq } from "drizzle-orm";
 import { NextApiRequest, NextApiResponse } from "next";
 
 const WORKFLOW_API_KEY_SETTING = "workflow_api_key";
 const WORKFLOW_KEY_NAME = "Power Tools Workflow Key";
-const WORKFLOW_PERMISSIONS = [
-  "asset.read",
-  "asset.update",
-  "album.read",
-  "album.create",
-  "album.update",
-  "tag.create",
-];
+const WORKFLOW_PERMISSIONS = [...WORKFLOW_API_KEY_PERMISSIONS];
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") return res.status(405).json({ message: "Method not allowed" });

--- a/src/pages/api/settings/validate-api-key.ts
+++ b/src/pages/api/settings/validate-api-key.ts
@@ -1,14 +1,7 @@
 import { ENV } from "@/config/environment";
 import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
+import { WORKFLOW_API_KEY_PERMISSIONS } from "@/lib/workflow/permissions";
 import { NextApiRequest, NextApiResponse } from "next";
-
-const WORKFLOW_PERMISSIONS = [
-  "asset.read",
-  "asset.update",
-  "album.create",
-  "album.update",
-  "tag.create",
-];
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") return res.status(405).json({ message: "Method not allowed" });
@@ -19,7 +12,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const { apiKey, requiredPermissions } = req.body;
   if (!apiKey) return res.status(400).json({ message: "apiKey is required" });
 
-  const REQUIRED_PERMISSIONS: string[] = Array.isArray(requiredPermissions) ? requiredPermissions : WORKFLOW_PERMISSIONS;
+  const REQUIRED_PERMISSIONS: string[] = Array.isArray(requiredPermissions)
+    ? requiredPermissions
+    : [...WORKFLOW_API_KEY_PERMISSIONS];
 
   try {
     const keyRes = await fetch(`${ENV.IMMICH_URL}/api/api-keys/me`, {

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import API from "@/lib/api";
 import { useConfig } from "@/contexts/ConfigContext";
+import { WORKFLOW_API_KEY_PERMISSIONS } from "@/lib/workflow/permissions";
 import Link from "next/link";
 
 function ConnectionStatus({ label, url, icon: Icon }: { label: string; url: string; icon: any }) {
@@ -251,7 +252,7 @@ export default function SettingsPage() {
                   )}
                 </div>
                 <div className="flex flex-wrap gap-1">
-                  {["asset.read", "asset.update", "album.create", "album.update", "tag.create"].map((p) => {
+                  {WORKFLOW_API_KEY_PERMISSIONS.map((p) => {
                     const granted = validationResult.permissions.includes(p);
                     const missing = validationResult.missing.includes(p);
                     return (
@@ -269,7 +270,7 @@ export default function SettingsPage() {
             )}
             {!validationResult && (
               <div className="flex flex-wrap gap-1">
-                {["asset.read", "asset.update", "album.create", "album.update", "tag.create"].map((p) => (
+                {WORKFLOW_API_KEY_PERMISSIONS.map((p) => (
                   <Badge key={p} variant="outline" className="text-[10px] h-5 font-mono font-normal">{p}</Badge>
                 ))}
               </div>


### PR DESCRIPTION
## Summary

The three places that deal with the Workflow API key each listed a different permission set, so a user who creates an Immich API key matching the UI badges (or even just lets the built-in auto-generator do it) can still end up with *"Invalid API key — could not authenticate with Immich"* on Save.

| Location | Permissions listed |
|---|---|
| UI (`settings/index.tsx` badges) | `asset.read`, `asset.update`, `album.create`, `album.update`, `tag.create` (5) |
| Validator (`validate-api-key.ts`) | same 5 |
| Auto-generator (`generate-workflow-api-key.ts`) | adds `album.read` → 6 |

On top of that, the validator itself starts by calling `/api/users/me`, which requires `user.read`. If the saved key does not include `user.read`, the validator returns the "Invalid API key" error *before* any of the listed permissions are even tested, with no hint why. `user.read` was not listed anywhere in the UI, the validator's `REQUIRED_PERMISSIONS`, or the auto-generator's `WORKFLOW_PERMISSIONS`.

## Repro (before this PR)

1. Immich → Account Settings → API Keys → "New API Key".
2. Tick exactly the five permissions the UI badges show: `asset.read`, `asset.update`, `album.create`, `album.update`, `tag.create`.
3. Paste the generated secret into **Workflow API Key** in Power Tools Settings → Save.
4. → *"Invalid API key — could not authenticate with Immich"*.

Even using the auto-generator path produces a usable key by accident (it adds `album.read`) but still doesn't include `user.read` — it works today only because the key inherits full-user auth via the same creator identity; the current code path happens to succeed, not by design.

## Fix

- Extract the real required set to `src/lib/workflow/permissions.ts` as `WORKFLOW_API_KEY_PERMISSIONS`:

  ```
  user.read
  asset.read
  asset.update
  album.read
  album.create
  album.update
  tag.create
  ```

- Import that constant in the three consumers (`settings/index.tsx`, `validate-api-key.ts`, `generate-workflow-api-key.ts`) so they stay in sync going forward.
- Add the two missing probes (`user.read`, `album.read`) to the validator so the granted/missing breakdown shown to the user is honest.

## Test plan

- [x] Manual: create an Immich key with exactly the seven permissions above → Save works, validator shows all green.
- [x] Manual: create a key missing `user.read` → validator returns the original auth-error message (unchanged), with `user.read` in `missing[]` so the UI badge turns red, which is more informative than before.
- [ ] Unit tests for `validate-api-key` covering both branches.

## Related

Found while setting up Power Tools for a fresh Immich deployment. Part of a small cluster of Find/settings fixes:

- #263 — Find auth (use `getUserHeaders()` instead of `Bearer undefined`)
- #264 — drop AI-hallucinated `takenAfter: <today>`