### PR TITLE
fix(AssetGrid): allow modifier-click to start a selection from zero

### DIFF
--- a/src/components/shared/AssetGrid.tsx
+++ b/src/components/shared/AssetGrid.tsx
@@ -150,7 +150,11 @@ const AssetGrid = forwardRef<AssetGridRef, AssetGridProps>(({ assets, isInternal
   };
 
   const handleClick = (index: number, asset: AssetPhoto, event: React.MouseEvent) => {
-    if (selectable && (event.metaKey || event.ctrlKey || selectedIds.length > 0)) {
+    // shiftKey lets the user enter selection mode from zero (start a range
+    // even when nothing is selected yet). Without it, the first click has
+    // no entry point to selection because the floating "Select all" bar
+    // only appears after something is already selected.
+    if (selectable && (event.metaKey || event.ctrlKey || event.shiftKey || selectedIds.length > 0)) {
       handleSelect(index, asset, event);
     } else {
       setIndex(index);


### PR DESCRIPTION
## Summary

`AssetGrid.handleClick` has two branches: toggle selection if `selectedIds.length > 0`, otherwise open the lightbox. The floating bar with *Select all* / *Add to album* only renders after `selectedIds.length > 0`. That leaves **no way to initiate a selection from a fresh grid** — every plain click goes to the lightbox, and the floating bar never has a chance to appear.

This blocks the canonical flow on Potential Albums (cluster a day's photos → create album) and affects any page that uses `AssetGrid` with `selectable` (Find results, etc.).

## Repro (before)

1. Albums → Potential Albums → pick any date in the left panel.
2. Click any photo in the right grid.
3. Lightbox opens; *Add to album* is never reachable.

## Fix

Treat **cmd/ctrl/shift + click** as an explicit "toggle selection" gesture regardless of current selection size. Plain click behaviour is unchanged:

- No modifier, nothing selected → open lightbox (as today).
- No modifier, something selected → toggle selection (as today).
- Modifier + click → toggle selection (NEW — this is the entry point).

Two-line code change in `src/components/shared/AssetGrid.tsx`.

## Test plan

- [x] Manual: Potential Albums → cmd+click a photo → selected. Floating bar shows. *Select all* → 700 selected → *Add to album* → *Create New* → works.
- [x] Manual: Plain click with 0 selected → still opens lightbox.
- [x] Manual: Plain click with ≥1 selected → still toggles (unchanged).
- [ ] Consider a visible hint in the UI (hover checkbox overlay, "cmd+click to select" tooltip) — out of scope here, happy to follow up.

## Related

Part of a small cluster of Find/settings fixes being upstreamed:
- #263 — Find auth `getUserHeaders()`
- #264 — drop AI-hallucinated `takenAfter: <today>`
- #265 — Workflow API key permissions sync