### PR TITLE
fix(AssetGrid): dim non-selected siblings during selection mode

### DIFF
--- a/src/components/shared/AssetGrid.tsx
+++ b/src/components/shared/AssetGrid.tsx
@@ -216,6 +216,7 @@ const AssetGrid = forwardRef<AssetGridRef, AssetGridProps>(({ assets, isInternal
         height={context.height}
         selectable={selectable}
         onSelect={(event) => handleSelect(context.index, context.photo, event)}
+        selectionMode={selectable && selectedIds.length > 0}
       />
     );
   };

--- a/src/components/ui/lazy-grid-image.tsx
+++ b/src/components/ui/lazy-grid-image.tsx
@@ -13,15 +13,17 @@ interface LazyGridImageProps {
   height: number;
   selectable?: boolean;
   onSelect?: (event: React.MouseEvent) => void;
+  /** When true, dim non-selected siblings so the selected set is visible in dense grids. */
+  selectionMode?: boolean;
 }
 
-export default function LazyGridImage({ imageProps, photo, width, height, selectable, onSelect }: LazyGridImageProps) {
+export default function LazyGridImage({ imageProps, photo, width, height, selectable, onSelect, selectionMode = false }: LazyGridImageProps) {
   const [isVisible, setIsVisible] = React.useState(false)
   const imageRef = React.useRef<HTMLDivElement>(null)
 
   const setupObserver = () => {
     const observer = new IntersectionObserver((entries) => {
-      
+
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           setIsVisible(true)
@@ -47,14 +49,16 @@ export default function LazyGridImage({ imageProps, photo, width, height, select
     <div style={{ height, width }} ref={imageRef} />
   )
 
+  const dim = selectionMode && !photo.isSelected ? 'opacity-60' : '';
+
   return (
-    <div 
-      style={{ 
-        position: 'relative', 
-        width, 
+    <div
+      style={{
+        position: 'relative',
+        width,
         height,
       }}
-      className={`group ${photo.isSelected ? 'ring-4 ring-blue-500 ring-inset' : ''}`}
+      className={`group ${photo.isSelected ? 'ring-4 ring-blue-500 ring-inset' : ''} ${dim}`.trim()}
     >
       <img {...imageProps} alt={imageProps.alt || ""} title="" style={{ ...imageProps.style, width, height, objectFit: 'cover' }} />
       {photo.isVideo && <div className="absolute bottom-2 right-2 bg-black/50 p-1 rounded-full flex items-center gap-1">
@@ -62,7 +66,7 @@ export default function LazyGridImage({ imageProps, photo, width, height, select
         {!!photo.duration && <span className="text-xs text-white">{humanizeDuration(photo.duration)}</span>}
       </div>}
       {selectable && (
-        <div 
+        <div
           className={`absolute top-2 left-2 z-10 cursor-pointer transition-opacity ${photo.isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}
           onClick={(e) => {
             e.stopPropagation();


### PR DESCRIPTION
Upstream now ships the selected-ring + clickable check badge on each thumbnail (great work), but in dense grids it can still be hard to see at a glance how much you've selected. This PR adds the missing piece: a slight opacity reduction (`opacity-60`) on non-selected items while a selection is in progress.

## Change
* New optional `selectionMode` prop on `LazyGridImage` (default `false`).
* `AssetGrid` passes `selectionMode={selectable && selectedIds.length > 0}`.
* When `selectionMode && !photo.isSelected`, the container gets `opacity-60`.

Purely additive; no behavior changes when nothing is selected.

## Why this matters
On large grids (potential trips, a bulk find result) the existing ring is easy to lose track of when you're selecting many photos. Dimming the rest gives instant visual contrast.