### PR TITLE
fix: restore gallery grid selection UI

### DIFF
--- a/src/components/shared/AssetGrid.tsx
+++ b/src/components/shared/AssetGrid.tsx
@@ -121,7 +121,7 @@ const AssetGrid = forwardRef<AssetGridRef, AssetGridProps>(({ assets, isInternal
 
 
   const handleClick = (index: number, asset: AssetPhoto, event: React.MouseEvent) => {
-    if (selectedIds.length > 0) {
+    if (selectable && (event.metaKey || event.ctrlKey || selectedIds.length > 0)) {
       handleSelect(index, asset, event);
     } else {
       setIndex(index);
@@ -214,6 +214,8 @@ const AssetGrid = forwardRef<AssetGridRef, AssetGridProps>(({ assets, isInternal
         photo={context.photo}
         width={context.width}
         height={context.height}
+        selectable={selectable}
+        onSelect={(event) => handleSelect(context.index, context.photo, event)}
       />
     );
   };

--- a/src/components/shared/AssetGrid.tsx
+++ b/src/components/shared/AssetGrid.tsx
@@ -120,14 +120,6 @@ const AssetGrid = forwardRef<AssetGridRef, AssetGridProps>(({ assets, isInternal
   }), [assets, selectedIds, updateContext]);
 
 
-  const handleClick = (index: number, asset: AssetPhoto, event: React.MouseEvent) => {
-    if (selectable && (event.metaKey || event.ctrlKey || selectedIds.length > 0)) {
-      handleSelect(index, asset, event);
-    } else {
-      setIndex(index);
-    }
-  }
-
   const handleSelect = (_idx: number, asset: AssetPhoto, event: React.MouseEvent) => {
 
     event.stopPropagation();
@@ -156,6 +148,14 @@ const AssetGrid = forwardRef<AssetGridRef, AssetGridProps>(({ assets, isInternal
       setLastSelectedIndex(clickedIndex);
     }
   };
+
+  const handleClick = (index: number, asset: AssetPhoto, event: React.MouseEvent) => {
+    if (selectable && (event.metaKey || event.ctrlKey || selectedIds.length > 0)) {
+      handleSelect(index, asset, event);
+    } else {
+      setIndex(index);
+    }
+  }
 
   const slides = useMemo(() => {
     return assets.filter((asset) => !deletedIds.has(asset.id)).map((asset) => ({

--- a/src/components/shared/ResponsiveVirtualizedAssetGrid.tsx
+++ b/src/components/shared/ResponsiveVirtualizedAssetGrid.tsx
@@ -112,14 +112,6 @@ const ResponsiveVirtualizedAssetGrid = forwardRef<ResponsiveVirtualizedAssetGrid
     }));
   }, [assets]);
 
-  const handleClick = useCallback((index: number, asset: IAsset, event: React.MouseEvent<HTMLElement>) => {
-    if (selectable && (event.metaKey || event.ctrlKey || selectedIds.length > 0)) {
-      handleSelect(index, asset, event);
-    } else {
-      setIndex(index);
-    }
-  }, [selectedIds, selectable, handleSelect]);
-
   const handleSelect = useCallback((_idx: number, asset: IAsset, event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();
     const isPresent = selectedIds.includes(asset.id);
@@ -145,6 +137,14 @@ const ResponsiveVirtualizedAssetGrid = forwardRef<ResponsiveVirtualizedAssetGrid
       setLastSelectedIndex(clickedIndex);
     }
   }, [selectedIds, assets, lastSelectedIndex, updateContext, onSelectionChange]);
+
+  const handleClick = useCallback((index: number, asset: IAsset, event: React.MouseEvent<HTMLElement>) => {
+    if (selectable && (event.metaKey || event.ctrlKey || selectedIds.length > 0)) {
+      handleSelect(index, asset, event);
+    } else {
+      setIndex(index);
+    }
+  }, [selectedIds, selectable, handleSelect]);
 
   const handleEsc = useCallback((event: KeyboardEvent) => {
     if (event.key === "Escape") {

--- a/src/components/shared/ResponsiveVirtualizedAssetGrid.tsx
+++ b/src/components/shared/ResponsiveVirtualizedAssetGrid.tsx
@@ -113,12 +113,12 @@ const ResponsiveVirtualizedAssetGrid = forwardRef<ResponsiveVirtualizedAssetGrid
   }, [assets]);
 
   const handleClick = useCallback((index: number, asset: IAsset, event: React.MouseEvent<HTMLElement>) => {
-    if (selectedIds.length > 0) {
+    if (selectable && (event.metaKey || event.ctrlKey || selectedIds.length > 0)) {
       handleSelect(index, asset, event);
     } else {
       setIndex(index);
     }
-  }, [selectedIds]);
+  }, [selectedIds, selectable, handleSelect]);
 
   const handleSelect = useCallback((_idx: number, asset: IAsset, event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();
@@ -200,11 +200,15 @@ const ResponsiveVirtualizedAssetGrid = forwardRef<ResponsiveVirtualizedAssetGrid
           )}
           {selectable && (
             <div 
-              className={`absolute top-2 left-2 w-4 h-4 rounded-full border-2 ${
+              className={`absolute top-2 left-2 w-4 h-4 rounded-full border-2 cursor-pointer z-10 ${
                 isSelected 
                   ? 'bg-blue-500 border-blue-500' 
                   : 'bg-white/80 border-gray-300'
               }`}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleSelect(assetIndex, asset, e);
+              }}
             />
           )}
         </div>

--- a/src/components/shared/VirtualizedAssetGrid.tsx
+++ b/src/components/shared/VirtualizedAssetGrid.tsx
@@ -77,12 +77,12 @@ const VirtualizedAssetGrid = forwardRef<VirtualizedAssetGridRef, VirtualizedAsse
   }, [assets]);
 
   const handleClick = useCallback((index: number, asset: IAsset, event: React.MouseEvent<HTMLElement>) => {
-    if (selectedIds.length > 0) {
+    if (selectable && (event.metaKey || event.ctrlKey || selectedIds.length > 0)) {
       handleSelect(index, asset, event);
     } else {
       setIndex(index);
     }
-  }, [selectedIds]);
+  }, [selectedIds, selectable, handleSelect]);
 
   const handleSelect = useCallback((_idx: number, asset: IAsset, event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();
@@ -166,11 +166,15 @@ const VirtualizedAssetGrid = forwardRef<VirtualizedAssetGridRef, VirtualizedAsse
           )}
           {selectable && (
             <div 
-              className={`absolute top-2 left-2 w-4 h-4 rounded-full border-2 ${
+              className={`absolute top-2 left-2 w-4 h-4 rounded-full border-2 cursor-pointer z-10 ${
                 isSelected 
                   ? 'bg-blue-500 border-blue-500' 
                   : 'bg-white/80 border-gray-300'
               }`}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleSelect(assetIndex, asset, e);
+              }}
             />
           )}
         </div>

--- a/src/components/shared/VirtualizedAssetGrid.tsx
+++ b/src/components/shared/VirtualizedAssetGrid.tsx
@@ -76,14 +76,6 @@ const VirtualizedAssetGrid = forwardRef<VirtualizedAssetGridRef, VirtualizedAsse
     }));
   }, [assets]);
 
-  const handleClick = useCallback((index: number, asset: IAsset, event: React.MouseEvent<HTMLElement>) => {
-    if (selectable && (event.metaKey || event.ctrlKey || selectedIds.length > 0)) {
-      handleSelect(index, asset, event);
-    } else {
-      setIndex(index);
-    }
-  }, [selectedIds, selectable, handleSelect]);
-
   const handleSelect = useCallback((_idx: number, asset: IAsset, event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();
     const isPresent = selectedIds.includes(asset.id);
@@ -109,6 +101,14 @@ const VirtualizedAssetGrid = forwardRef<VirtualizedAssetGridRef, VirtualizedAsse
       setLastSelectedIndex(clickedIndex);
     }
   }, [selectedIds, assets, lastSelectedIndex, updateContext, onSelectionChange]);
+
+  const handleClick = useCallback((index: number, asset: IAsset, event: React.MouseEvent<HTMLElement>) => {
+    if (selectable && (event.metaKey || event.ctrlKey || selectedIds.length > 0)) {
+      handleSelect(index, asset, event);
+    } else {
+      setIndex(index);
+    }
+  }, [selectedIds, selectable, handleSelect]);
 
   const handleEsc = useCallback((event: KeyboardEvent) => {
     if (event.key === "Escape") {

--- a/src/components/ui/lazy-grid-image.tsx
+++ b/src/components/ui/lazy-grid-image.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 import { humanizeDuration } from '@/helpers/string.helper'
 import { PlayIcon } from '@radix-ui/react-icons'
+import { CircleCheck } from 'lucide-react'
 import React, { useEffect } from 'react'
 import type { RenderImageProps } from 'react-photo-album'
 import type { AssetPhoto } from '../shared/AssetGrid'
@@ -10,9 +11,11 @@ interface LazyGridImageProps {
   photo: AssetPhoto;
   width: number;
   height: number;
+  selectable?: boolean;
+  onSelect?: (event: React.MouseEvent) => void;
 }
 
-export default function LazyGridImage({ imageProps, photo, width, height }: LazyGridImageProps) {
+export default function LazyGridImage({ imageProps, photo, width, height, selectable, onSelect }: LazyGridImageProps) {
   const [isVisible, setIsVisible] = React.useState(false)
   const imageRef = React.useRef<HTMLDivElement>(null)
 
@@ -45,12 +48,32 @@ export default function LazyGridImage({ imageProps, photo, width, height }: Lazy
   )
 
   return (
-    <div style={{ position: 'relative', width, height }}>
+    <div 
+      style={{ 
+        position: 'relative', 
+        width, 
+        height,
+      }}
+      className={`group ${photo.isSelected ? 'ring-4 ring-blue-500 ring-inset' : ''}`}
+    >
       <img {...imageProps} alt={imageProps.alt || ""} title="" style={{ ...imageProps.style, width, height, objectFit: 'cover' }} />
       {photo.isVideo && <div className="absolute bottom-2 right-2 bg-black/50 p-1 rounded-full flex items-center gap-1">
         <PlayIcon className="w-3 h-3 text-white" />
         {!!photo.duration && <span className="text-xs text-white">{humanizeDuration(photo.duration)}</span>}
       </div>}
+      {selectable && (
+        <div 
+          className={`absolute top-2 left-2 z-10 cursor-pointer transition-opacity ${photo.isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect?.(e);
+          }}
+        >
+          <div className={`rounded-full p-0.5 ${photo.isSelected ? 'bg-blue-500 text-white' : 'bg-black/20 text-white/50'}`}>
+            <CircleCheck className="w-5 h-5" />
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
This PR restores the selection UI in the gallery grid which was lost during the migration to react-photo-album. It also enables starting a selection by clicking the selection icon or using Meta/Ctrl keys.