### PR TITLE
fix: API key permissions for Immich v3 (albumAsset.*, tag.asset) and honor "all" in key validation

### DIFF
--- a/src/config/permissions.ts
+++ b/src/config/permissions.ts
@@ -8,7 +8,8 @@ export const IMPORT_PERMISSIONS: Permission[] = [
   { name: "asset.upload", description: "Upload new assets" },
   { name: "album.read", description: "Read album data" },
   { name: "album.create", description: "Create new albums" },
-  { name: "album.update", description: "Add assets to albums" },
+  { name: "album.update", description: "Update album metadata" },
+  { name: "albumAsset.create", description: "Add assets to albums" },
   { name: "tag.create", description: "Tag imported assets" },
   { name: "tag.asset", description: "Assign tags to assets" },
 ];
@@ -18,8 +19,11 @@ export const WORKFLOW_PERMISSIONS: Permission[] = [
   { name: "asset.update", description: "Favorite, archive, update metadata" },
   { name: "album.read", description: "Read album data" },
   { name: "album.create", description: "Create new albums" },
-  { name: "album.update", description: "Add/remove assets from albums" },
-  { name: "tag.create", description: "Create and assign tags" },
+  { name: "album.update", description: "Update album metadata" },
+  { name: "albumAsset.create", description: "Add assets to albums" },
+  { name: "albumAsset.delete", description: "Remove assets from albums" },
+  { name: "tag.create", description: "Create tags" },
+  { name: "tag.asset", description: "Assign tags to assets" },
 ];
 
 export const getPermissionNames = (permissions: Permission[]): string[] =>

--- a/src/pages/api/settings/validate-api-key.ts
+++ b/src/pages/api/settings/validate-api-key.ts
@@ -30,7 +30,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const keyData = await keyRes.json();
     const granted: string[] = keyData.permissions ?? [];
-    const missing = REQUIRED_PERMISSIONS.filter((p) => !granted.includes(p));
+    // A key created with the "All" checkbox reports its permissions as ["all"],
+    // which grants every permission without listing them individually.
+    const missing = granted.includes("all")
+      ? []
+      : REQUIRED_PERMISSIONS.filter((p) => !granted.includes(p));
 
     return res.status(200).json({
       valid: missing.length === 0,


### PR DESCRIPTION
## Problem

On Immich v3, every workflow run that adds assets to an album fails with:

```
Immich API error 403: {"message":"Missing required permission: albumAsset.create"}
```

Two bugs stack up to make this unrecoverable from the UI:

1. **Stale permission list.** Immich v3 split album-membership rights out of `album.update` into the granular `albumAsset.create` / `albumAsset.delete` permissions, and assigning tags to assets requires `tag.asset`. `WORKFLOW_PERMISSIONS` predates this split, so the auto-generated "Power Tools Workflow Key" lacks the permissions the workflow executor actually needs — `actionExecutor.ts` calls `PUT /albums/:id/assets` (needs `albumAsset.create`), `DELETE /albums/:id/assets` (needs `albumAsset.delete`), and `PUT /tags/:id/assets` (needs `tag.asset`). The "Add to Album", "Remove from Album", and "Add Tag" actions all 403 at runtime. `IMPORT_PERMISSIONS` has the same issue for adding imported assets to albums.

2. **Validator rejects full-permission keys.** The natural user workaround — creating a key in Immich with the "All" checkbox — also fails: such a key reports its permissions as `["all"]`, and `validate-api-key.ts` literal-matches each required permission name against that list, so *every* permission shows as missing. Since the settings page refuses to save a key that fails validation, there is no way to supply a working key through the UI.

## Fix

- Add `albumAsset.create`, `albumAsset.delete`, and `tag.asset` to `WORKFLOW_PERMISSIONS`, and `albumAsset.create` to `IMPORT_PERMISSIONS`, matching the endpoints actually called. `album.update` is kept (still used for album metadata, and for compatibility with pre-split Immich versions).
- In `validate-api-key.ts`, treat a granted `all` permission as satisfying all requirements.

Both the key auto-generation endpoints and the settings-page permission chips read from `src/config/permissions.ts`, so no other changes are needed.

## Testing

- Reproduced on Immich v3.0.1 with Power Tools v0.22.0: workflow with an "Add to Album" action fails 403 with the stock generated key; an all-permissions key is rejected by settings validation.
- Confirmed a key carrying the updated permission set validates, saves, and the same workflow run completes and adds assets to the album.
- `tsc --noEmit` reports no errors in the touched files.

Follow-up to #294 (Immich v3.0 compatibility), which didn't cover the API-key permission lists.

Note for older Immich servers: the `albumAsset.*` permissions only exist on Immich versions that include the permission split; on servers older than that, key generation with this list would be rejected by Immich. If you still support pre-split versions, happy to gate the list on the server version instead — let me know which way you'd like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
