### PR TITLE
feat: Tag condition for workflow IF/SWITCH nodes (hierarchical, any/all/none)

### DIFF
--- a/src/components/workflows/config/ConditionEditor.tsx
+++ b/src/components/workflows/config/ConditionEditor.tsx
@@ -4,8 +4,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { ICondition, ConditionType } from "@/types/workflow";
-import { Plus, X, Check } from "lucide-react";
+import { Plus, X, Check, Tag } from "lucide-react";
 import { listPeople } from "@/handlers/api/people.handler";
+import { listTags, ITag } from "@/handlers/api/tag.handler";
 import { IPerson } from "@/types/person";
 import { PERSON_THUBNAIL_PATH } from "@/config/routes";
 import { useEffect, useState } from "react";
@@ -14,6 +15,7 @@ import { cn } from "@/lib/utils";
 const conditionTypeLabels: Record<ConditionType, string> = {
   person: "Person",
   person_unnamed: "Unnamed People",
+  tag: "Tag",
   city: "City",
   state: "State",
   country: "Country",
@@ -124,6 +126,95 @@ function PersonPicker({ selectedIds, onChange }: PersonPickerProps) {
   );
 }
 
+interface TagPickerProps {
+  selectedIds: string[];
+  onChange: (tagIds: string[], tagValues: string[]) => void;
+}
+
+function TagPicker({ selectedIds, onChange }: TagPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [tags, setTags] = useState<ITag[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    listTags()
+      .then((res) => setTags(res.tags))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const selectedSet = new Set(selectedIds || []);
+  const selectedTags = tags.filter((t) => selectedSet.has(t.id));
+
+  const toggleTag = (tag: ITag) => {
+    let nextIds: string[];
+    let nextValues: string[];
+    if (selectedSet.has(tag.id)) {
+      nextIds = selectedIds.filter((id) => id !== tag.id);
+      nextValues = selectedTags.filter((t) => t.id !== tag.id).map((t) => t.value);
+    } else {
+      nextIds = [...selectedIds, tag.id];
+      nextValues = [...selectedTags.map((t) => t.value), tag.value];
+    }
+    onChange(nextIds, nextValues);
+  };
+
+  return (
+    <div className="space-y-2">
+      {/* Selected tag chips */}
+      {selectedTags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {selectedTags.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => toggleTag(t)}
+              className="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-muted hover:bg-destructive/10 transition-colors group"
+            >
+              <Tag className="h-2.5 w-2.5" style={t.color ? { color: t.color } : undefined} />
+              <span className="text-[10px] font-medium">{t.value}</span>
+              <X className="h-2.5 w-2.5 text-muted-foreground group-hover:text-destructive" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Picker */}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button type="button" className="flex items-center gap-2 h-7 px-2 w-full border rounded text-xs bg-background hover:bg-muted transition-colors">
+            <span className="text-muted-foreground">
+              {selectedIds.length === 0 ? "Select tags..." : "Add more..."}
+            </span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-56 p-0 z-[10000]" align="start">
+          <Command>
+            <CommandInput placeholder="Search tags..." className="text-xs" />
+            <CommandList>
+              <CommandEmpty>{loading ? "Loading..." : "No tags found."}</CommandEmpty>
+              <CommandGroup>
+                {tags.map((tag) => (
+                  <CommandItem
+                    key={tag.id}
+                    value={tag.value}
+                    onSelect={() => toggleTag(tag)}
+                    className="flex items-center gap-2"
+                  >
+                    <Tag className="h-3 w-3" style={tag.color ? { color: tag.color } : undefined} />
+                    <span className="text-xs truncate flex-1">{tag.value}</span>
+                    <Check className={cn("h-3 w-3", selectedSet.has(tag.id) ? "opacity-100" : "opacity-0")} />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
 interface ConditionEditorProps {
   conditions: ICondition[];
   onChange: (conditions: ICondition[]) => void;
@@ -217,6 +308,24 @@ function ConditionFields({ condition, onChange }: { condition: ICondition; onCha
             selectedIds={condition.personIds || (condition.personId ? [condition.personId] : [])}
             onChange={(personIds, personNames) => onChange({ ...condition, personIds, personNames })}
           />
+        </div>
+      );
+    case "tag":
+      return (
+        <div className="space-y-2">
+          <Select value={condition.match || "contains_any"} onValueChange={(v) => onChange({ ...condition, match: v })}>
+            <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="contains_any">Has any of</SelectItem>
+              <SelectItem value="contains_all">Has all of</SelectItem>
+              <SelectItem value="not_contains">Has none of</SelectItem>
+            </SelectContent>
+          </Select>
+          <TagPicker
+            selectedIds={condition.tagIds || []}
+            onChange={(tagIds, tagValues) => onChange({ ...condition, tagIds, tagValues })}
+          />
+          <p className="text-[10px] text-muted-foreground">Selected tags also match their child tags.</p>
         </div>
       );
     case "geo_radius":

--- a/src/components/workflows/nodes/conditionSummary.ts
+++ b/src/components/workflows/nodes/conditionSummary.ts
@@ -3,6 +3,7 @@ import { ICondition, ConditionType } from "@/types/workflow";
 const conditionTypeLabels: Record<ConditionType, string> = {
   person: "Person",
   person_unnamed: "Unnamed People",
+  tag: "Tag",
   city: "City",
   state: "State",
   country: "Country",
@@ -45,6 +46,13 @@ export function formatConditionSummary(c: ICondition): string {
     }
     case "person_unnamed":
       return label;
+    case "tag": {
+      const values: string[] = c.tagValues || [];
+      const match = matchLabels[c.match] || c.match || "any of";
+      if (values.length === 0) return `${label}: (none selected)`;
+      const valueStr = values.length <= 2 ? values.join(", ") : `${values[0]}, ${values[1]} +${values.length - 2}`;
+      return `${label} ${match}: ${valueStr}`;
+    }
     case "city":
     case "state":
     case "country": {

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -7,6 +7,7 @@ export const LOGOUT_PATH = BASE_API_ENDPOINT + "/users/logout";
 
 
 export const LIST_PEOPLE_PATH = BASE_API_ENDPOINT + "/people/list";
+export const LIST_TAGS_PATH = BASE_API_ENDPOINT + "/tags";
 export const SEARCH_PEOPLE_PATH = BASE_PROXY_ENDPOINT + "/search/person";
 export const SIMILAR_FACES_PATH = (id: string) => BASE_API_ENDPOINT + "/people/" + id + "/similar-faces";
 export const PERSON_THUBNAIL_PATH = (id: string) => BASE_PROXY_ENDPOINT + "/thumbnail/" + id;

--- a/src/handlers/api/tag.handler.ts
+++ b/src/handlers/api/tag.handler.ts
@@ -1,0 +1,13 @@
+import { LIST_TAGS_PATH } from "@/config/routes";
+import API from "@/lib/api";
+
+export interface ITag {
+  id: string;
+  value: string;
+  color: string | null;
+  parentId: string | null;
+}
+
+export const listTags = (): Promise<{ tags: ITag[] }> => {
+  return API.get(LIST_TAGS_PATH);
+};

--- a/src/lib/workflow/conditionBuilder.ts
+++ b/src/lib/workflow/conditionBuilder.ts
@@ -117,6 +117,36 @@ function buildSingleCondition(c: ICondition): SQL | undefined {
       return sql`EXISTS (SELECT 1 FROM "asset_face" af WHERE af."assetId" = ${assets.id} AND af."personId" IN (${sql.raw(idList)}))`;
     }
 
+    case "tag": {
+      const ids: string[] = c.tagIds || [];
+      if (ids.length === 0) return undefined;
+
+      // A selected tag also matches assets tagged with any of its child tags
+      // (tag_closure holds the hierarchy, including self-references).
+      const descendants = (tagId: string) =>
+        sql`(SELECT tc."id_descendant" FROM "tag_closure" tc WHERE tc."id_ancestor" = ${tagId})`;
+
+      if (c.match === "not_contains") {
+        // Asset must not carry ANY of these tags (or their children)
+        const checks = ids.map((tid: string) =>
+          sql`NOT EXISTS (SELECT 1 FROM "tag_asset" ta WHERE ta."assetId" = ${assets.id} AND (ta."tagId" = ${tid} OR ta."tagId" IN ${descendants(tid)}))`
+        );
+        return and(...checks)!;
+      }
+
+      if (c.match === "contains_all") {
+        // Asset must carry ALL of these tags (or their children)
+        const checks = ids.map((tid: string) =>
+          sql`EXISTS (SELECT 1 FROM "tag_asset" ta WHERE ta."assetId" = ${assets.id} AND (ta."tagId" = ${tid} OR ta."tagId" IN ${descendants(tid)}))`
+        );
+        return and(...checks)!;
+      }
+
+      // contains_any (default) — asset carries at least one of these tags (or their children)
+      const idList = ids.map((id: string) => `'${id}'`).join(",");
+      return sql`EXISTS (SELECT 1 FROM "tag_asset" ta WHERE ta."assetId" = ${assets.id} AND (ta."tagId" IN (${sql.raw(idList)}) OR ta."tagId" IN (SELECT tc."id_descendant" FROM "tag_closure" tc WHERE tc."id_ancestor" IN (${sql.raw(idList)}))))`;
+    }
+
     case "person_unnamed":
       if (c.match === "no_unnamed") {
         return sql`NOT EXISTS (SELECT 1 FROM "asset_face" af JOIN "person" p ON af."personId" = p.id WHERE af."assetId" = ${assets.id} AND (p.name = '' OR p.name IS NULL))`;

--- a/src/lib/workflow/conditionBuilder.ts
+++ b/src/lib/workflow/conditionBuilder.ts
@@ -143,8 +143,8 @@ function buildSingleCondition(c: ICondition): SQL | undefined {
       }
 
       // contains_any (default) — asset carries at least one of these tags (or their children)
-      const idList = ids.map((id: string) => `'${id}'`).join(",");
-      return sql`EXISTS (SELECT 1 FROM "tag_asset" ta WHERE ta."assetId" = ${assets.id} AND (ta."tagId" IN (${sql.raw(idList)}) OR ta."tagId" IN (SELECT tc."id_descendant" FROM "tag_closure" tc WHERE tc."id_ancestor" IN (${sql.raw(idList)}))))`;
+      const idParams = sql.join(ids.map((id: string) => sql`${id}`), sql`, `);
+      return sql`EXISTS (SELECT 1 FROM "tag_asset" ta WHERE ta."assetId" = ${assets.id} AND (ta."tagId" IN (${idParams}) OR ta."tagId" IN (SELECT tc."id_descendant" FROM "tag_closure" tc WHERE tc."id_ancestor" IN (${idParams}))))`;
     }
 
     case "person_unnamed":

--- a/src/pages/api/tags/index.ts
+++ b/src/pages/api/tags/index.ts
@@ -1,0 +1,30 @@
+import { db } from "@/config/db";
+import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
+import { tags } from "@/schema";
+import { asc, eq } from "drizzle-orm";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const currentUser = await getCurrentUser(req);
+    if (!currentUser) return res.status(401).json({ message: "Unauthorized" });
+
+    const rows = await db
+      .select({
+        id: tags.id,
+        value: tags.value,
+        color: tags.color,
+        parentId: tags.parentId,
+      })
+      .from(tags)
+      .where(eq(tags.userId, currentUser.id))
+      .orderBy(asc(tags.value));
+
+    return res.status(200).json({ tags: rows });
+  } catch (error: any) {
+    res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -4,4 +4,5 @@ export { person } from './person.schema';
 export { assetFaces } from './assetFaces.schema';
 export { users } from './users.schema';
 export { albumsAssetsAssets } from './albumAssetsAssets.schema';
+export { tags } from './tags.schema';
 export * from './relationships';

--- a/src/schema/tags.schema.ts
+++ b/src/schema/tags.schema.ts
@@ -1,0 +1,11 @@
+import { pgTable, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+
+export const tags = pgTable("tag", {
+  id: uuid("id").notNull().primaryKey(),
+  userId: uuid("userId").notNull(),
+  value: varchar("value").notNull(),
+  color: varchar("color"),
+  parentId: uuid("parentId"),
+  createdAt: timestamp("createdAt").notNull(),
+  updatedAt: timestamp("updatedAt").notNull(),
+});

--- a/src/types/workflow.d.ts
+++ b/src/types/workflow.d.ts
@@ -49,7 +49,7 @@ export interface IWorkflowWithDetails extends IWorkflow {
 }
 
 export type ConditionType =
-  | "person" | "person_unnamed"
+  | "person" | "person_unnamed" | "tag"
   | "city" | "state" | "country" | "geo_radius"
   | "date_range" | "date_relative" | "day_of_week"
   | "camera_make" | "camera_model" | "lens"


### PR DESCRIPTION
## What

Adds a **Tag** condition type for workflow IF/SWITCH nodes, filtering assets by their Immich tags with the same match modes as the person condition: *has any of*, *has all of*, *has none of*.

Selected tags also match their **child tags** through Immich's `tag_closure` hierarchy table — picking `Trips` matches assets tagged `Trips/2026/Banff` — mirroring how tag browsing behaves in Immich itself. (The SQL checks the picked ids directly as well as via the closure, so a tag without a self-closure row still matches.)

## Changes

- `conditionBuilder.ts` — `tag` case with `EXISTS` subqueries on `tag_asset`, descendant-inclusive via `tag_closure`
- `ConditionEditor.tsx` — "Tag" condition entry + `TagPicker` multi-select (same pattern as `PersonPicker`), chips tinted with the tag's color
- `conditionSummary.ts` — node summary ("Tag any of: Vacation, Professional +1")
- New `GET /api/tags` route listing the current user's tags, plus a client handler and a drizzle schema for Immich's `tag` table

## Tested

On a live library (Immich v3.0.1):

- `all_assets` (26,063 assets) → IF `tag has any of [Professional]` → `create_album`: matched **exactly 2,707 assets**, identical to the ground-truth `tag_asset` count for that tag, and the created album contained all 2,707.
- Hierarchy verified with a parent/child tag pair: an asset tagged only with the child matches a condition on the parent; a direct-only check does not.
- `tsc --noEmit` clean for the touched files.

Builds on the condition/query structure as-is; no schema or migration changes (conditions are stored as JSON in node data, so existing workflows are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
