### PR TITLE
feat: Resolution condition for workflow IF/SWITCH nodes (megapixels, short/long edge)

### DIFF
--- a/src/components/workflows/config/ConditionEditor.tsx
+++ b/src/components/workflows/config/ConditionEditor.tsx
@@ -27,6 +27,7 @@ const conditionTypeLabels: Record<ConditionType, string> = {
   asset_type: "Asset Type",
   iso_range: "ISO Range",
   focal_length: "Focal Length",
+  resolution: "Resolution",
   rating: "Rating",
   is_favorited: "Favorited",
   not_in_album: "Not in Any Album",
@@ -192,6 +193,25 @@ function ConditionFields({ condition, onChange }: { condition: ICondition; onCha
           <Input className="h-7 text-xs w-16" type="number" min={1} max={5} placeholder="Max" value={condition.max ?? ""} onChange={(e) => onChange({ ...condition, max: parseInt(e.target.value) || undefined })} />
         </div>
       );
+    case "resolution": {
+      const unit = (condition.metric || "megapixels") === "megapixels" ? "MP" : "px";
+      return (
+        <div className="space-y-2">
+          <Select value={condition.metric || "megapixels"} onValueChange={(v) => onChange({ ...condition, metric: v })}>
+            <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="megapixels">Megapixels</SelectItem>
+              <SelectItem value="short_edge">Short Edge (px)</SelectItem>
+              <SelectItem value="long_edge">Long Edge (px)</SelectItem>
+            </SelectContent>
+          </Select>
+          <div className="flex items-center gap-2">
+            <Input className="h-7 text-xs" type="number" min={0} step="any" placeholder={`Min ${unit}`} value={condition.min ?? ""} onChange={(e) => onChange({ ...condition, min: e.target.value === "" ? undefined : parseFloat(e.target.value) })} />
+            <Input className="h-7 text-xs" type="number" min={0} step="any" placeholder={`Max ${unit}`} value={condition.max ?? ""} onChange={(e) => onChange({ ...condition, max: e.target.value === "" ? undefined : parseFloat(e.target.value) })} />
+          </div>
+        </div>
+      );
+    }
     case "is_favorited":
       return (
         <Select value={condition.value === false ? "false" : "true"} onValueChange={(v) => onChange({ ...condition, value: v === "true" })}>

--- a/src/components/workflows/nodes/conditionSummary.ts
+++ b/src/components/workflows/nodes/conditionSummary.ts
@@ -16,6 +16,7 @@ const conditionTypeLabels: Record<ConditionType, string> = {
   asset_type: "Asset Type",
   iso_range: "ISO Range",
   focal_length: "Focal Length",
+  resolution: "Resolution",
   rating: "Rating",
   is_favorited: "Favorited",
   not_in_album: "Not in Any Album",
@@ -93,6 +94,16 @@ export function formatConditionSummary(c: ICondition): string {
       if (c.min != null && c.max != null) return `${label}: ${c.min}–${c.max}`;
       if (c.min != null) return `${label}: ≥${c.min}`;
       if (c.max != null) return `${label}: ≤${c.max}`;
+      return label;
+    }
+    case "resolution": {
+      const metricNames: Record<string, string> = { megapixels: "MP", short_edge: "short edge", long_edge: "long edge" };
+      const metric = c.metric || "megapixels";
+      const unit = metric === "megapixels" ? "MP" : "px";
+      const name = metric === "megapixels" ? "" : `${metricNames[metric]} `;
+      if (c.min != null && c.max != null) return `${label}: ${name}${c.min}–${c.max}${unit}`;
+      if (c.min != null) return `${label}: ${name}≥${c.min}${unit}`;
+      if (c.max != null) return `${label}: ${name}≤${c.max}${unit}`;
       return label;
     }
     case "is_favorited":

--- a/src/lib/workflow/conditionBuilder.ts
+++ b/src/lib/workflow/conditionBuilder.ts
@@ -92,6 +92,21 @@ function buildSingleCondition(c: ICondition): SQL | undefined {
       return parts.length > 0 ? and(...parts)! : undefined;
     }
 
+    case "resolution": {
+      // Short/long edge are orientation-agnostic; megapixels = width × height / 1e6.
+      const metric = c.metric || "megapixels";
+      const value =
+        metric === "short_edge"
+          ? sql`LEAST(${exif.exifImageWidth}, ${exif.exifImageHeight})`
+          : metric === "long_edge"
+            ? sql`GREATEST(${exif.exifImageWidth}, ${exif.exifImageHeight})`
+            : sql`(${exif.exifImageWidth}::bigint * ${exif.exifImageHeight}) / 1000000.0`;
+      const parts: SQL[] = [];
+      if (c.min !== undefined && c.min !== null) parts.push(sql`${value} >= ${c.min}`);
+      if (c.max !== undefined && c.max !== null) parts.push(sql`${value} <= ${c.max}`);
+      return parts.length > 0 ? and(...parts)! : undefined;
+    }
+
     case "person": {
       const ids: string[] = c.personIds || (c.personId ? [c.personId] : []);
       if (ids.length === 0) return undefined;

--- a/src/types/workflow.d.ts
+++ b/src/types/workflow.d.ts
@@ -54,7 +54,7 @@ export type ConditionType =
   | "date_range" | "date_relative" | "day_of_week"
   | "camera_make" | "camera_model" | "lens"
   | "asset_type" | "iso_range" | "focal_length"
-  | "rating" | "is_favorited"
+  | "rating" | "is_favorited" | "resolution"
   | "not_in_album" | "not_in_specific_album";
 
 export interface ICondition {


### PR DESCRIPTION
## What

Adds a **Resolution** condition type for workflow IF/SWITCH nodes, filtering assets by image dimensions — useful for cleaning out low-resolution images (e.g. old messenger downloads) or isolating high-resolution originals.

Three metrics, each with optional min/max bounds:

- **Megapixels** — `width × height / 1e6`, fractional values allowed (e.g. min 0.5)
- **Short edge (px)** — `LEAST(width, height)`
- **Long edge (px)** — `GREATEST(width, height)`

Short/long edge are orientation-agnostic: a 4000×3000 landscape and a 3000×4000 portrait behave identically, so users don't have to reason about width vs height.

## Changes

- `conditionBuilder.ts` — `resolution` case over `asset_exif.exifImageWidth/Height` (already joined by the condition queries); assets without recorded dimensions never match
- `ConditionEditor.tsx` — metric select + min/max inputs with unit hints (px/MP)
- `conditionSummary.ts` — node summary ("Resolution: short edge ≥2160px", "Resolution: 2–12MP")
- `workflow.d.ts` — type union entry

No new API routes, schema, or migration changes.

## Tested

On a live 26,063-asset library (Immich v3.0.1), each metric verified against ground-truth SQL over `asset_exif`:

| Condition | Ground truth | Workflow IF result |
|---|---|---|
| short edge ≥ 2160 | 24,892 | 24,892 → TRUE |
| long edge ≤ 1024 | 95 | 95 → TRUE |
| megapixels ≥ 20 | 15,038 | 15,038 → TRUE |

`tsc --noEmit` clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
