### PR TITLE
feat: five library-cleanup conditions — file size, name/path, extension, face count, time of day

### DIFF
--- a/src/components/workflows/config/ConditionEditor.tsx
+++ b/src/components/workflows/config/ConditionEditor.tsx
@@ -29,6 +29,11 @@ const conditionTypeLabels: Record<ConditionType, string> = {
   focal_length: "Focal Length",
   rating: "Rating",
   is_favorited: "Favorited",
+  file_size: "File Size",
+  filename: "File Name / Path",
+  file_extension: "File Extension",
+  face_count: "Face Count",
+  time_of_day: "Time of Day",
   not_in_album: "Not in Any Album",
   not_in_specific_album: "Not in Specific Album",
 };
@@ -201,6 +206,71 @@ function ConditionFields({ condition, onChange }: { condition: ICondition; onCha
             <SelectItem value="false">Not Favorited</SelectItem>
           </SelectContent>
         </Select>
+      );
+    case "file_size":
+      return (
+        <div className="flex items-center gap-2">
+          <Input className="h-7 text-xs" type="number" min={0} step="any" placeholder="Min MB" value={condition.min ?? ""} onChange={(e) => onChange({ ...condition, min: e.target.value === "" ? undefined : parseFloat(e.target.value) })} />
+          <Input className="h-7 text-xs" type="number" min={0} step="any" placeholder="Max MB" value={condition.max ?? ""} onChange={(e) => onChange({ ...condition, max: e.target.value === "" ? undefined : parseFloat(e.target.value) })} />
+        </div>
+      );
+    case "filename":
+      return (
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <Select value={condition.field || "name"} onValueChange={(v) => onChange({ ...condition, field: v })}>
+              <SelectTrigger className="h-7 text-xs w-28"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="name">File Name</SelectItem>
+                <SelectItem value="path">File Path</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={condition.match || "contains"} onValueChange={(v) => onChange({ ...condition, match: v })}>
+              <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="contains">Contains</SelectItem>
+                <SelectItem value="not_contains">Does not contain</SelectItem>
+                <SelectItem value="starts_with">Starts with</SelectItem>
+                <SelectItem value="ends_with">Ends with</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <Input className="h-7 text-xs" placeholder="e.g. Screenshot" value={condition.text || ""} onChange={(e) => onChange({ ...condition, text: e.target.value })} />
+        </div>
+      );
+    case "file_extension":
+      return (
+        <div className="space-y-2">
+          <Select value={condition.match || "in"} onValueChange={(v) => onChange({ ...condition, match: v })}>
+            <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="in">Is any of</SelectItem>
+              <SelectItem value="not_in">Is none of</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input className="h-7 text-xs" placeholder="e.g. png, gif, heic" value={condition.extensions || ""} onChange={(e) => onChange({ ...condition, extensions: e.target.value })} />
+        </div>
+      );
+    case "face_count":
+      return (
+        <div className="flex items-center gap-2">
+          <Input className="h-7 text-xs w-20" type="number" min={0} placeholder="Min" value={condition.min ?? ""} onChange={(e) => onChange({ ...condition, min: e.target.value === "" ? undefined : parseInt(e.target.value) })} />
+          <Input className="h-7 text-xs w-20" type="number" min={0} placeholder="Max" value={condition.max ?? ""} onChange={(e) => onChange({ ...condition, max: e.target.value === "" ? undefined : parseInt(e.target.value) })} />
+          <span className="text-xs text-muted-foreground">faces</span>
+        </div>
+      );
+    case "time_of_day":
+      return (
+        <div className="space-y-1">
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-muted-foreground">From</span>
+            <Input className="h-7 text-xs w-16" type="number" min={0} max={23} placeholder="0" value={condition.fromHour ?? ""} onChange={(e) => onChange({ ...condition, fromHour: e.target.value === "" ? undefined : parseInt(e.target.value) })} />
+            <span className="text-xs text-muted-foreground">to</span>
+            <Input className="h-7 text-xs w-16" type="number" min={0} max={23} placeholder="23" value={condition.toHour ?? ""} onChange={(e) => onChange({ ...condition, toHour: e.target.value === "" ? undefined : parseInt(e.target.value) })} />
+            <span className="text-xs text-muted-foreground">h</span>
+          </div>
+          <p className="text-[10px] text-muted-foreground">Hours 0–23; From &gt; To wraps past midnight (e.g. 22 to 5).</p>
+        </div>
       );
     case "person":
       return (

--- a/src/components/workflows/nodes/conditionSummary.ts
+++ b/src/components/workflows/nodes/conditionSummary.ts
@@ -18,6 +18,11 @@ const conditionTypeLabels: Record<ConditionType, string> = {
   focal_length: "Focal Length",
   rating: "Rating",
   is_favorited: "Favorited",
+  file_size: "File Size",
+  filename: "File Name / Path",
+  file_extension: "Extension",
+  face_count: "Faces",
+  time_of_day: "Time of Day",
   not_in_album: "Not in Any Album",
   not_in_specific_album: "Not in Specific Album",
 };
@@ -97,6 +102,32 @@ export function formatConditionSummary(c: ICondition): string {
     }
     case "is_favorited":
       return c.value === false ? "Not Favorited" : "Favorited";
+    case "file_size": {
+      if (c.min != null && c.max != null) return `${label}: ${c.min}–${c.max}MB`;
+      if (c.min != null) return `${label}: ≥${c.min}MB`;
+      if (c.max != null) return `${label}: ≤${c.max}MB`;
+      return label;
+    }
+    case "filename": {
+      if (!c.text) return label;
+      const field = c.field === "path" ? "Path" : "Name";
+      const matchNames: Record<string, string> = { contains: "contains", not_contains: "doesn't contain", starts_with: "starts with", ends_with: "ends with" };
+      return `${field} ${matchNames[c.match] || "contains"}: ${c.text}`;
+    }
+    case "file_extension": {
+      if (!c.extensions) return label;
+      return `${label} ${c.match === "not_in" ? "none of" : "any of"}: ${c.extensions}`;
+    }
+    case "face_count": {
+      if (c.min != null && c.max != null) return c.min === c.max ? `${label}: ${c.min}` : `${label}: ${c.min}–${c.max}`;
+      if (c.min != null) return `${label}: ≥${c.min}`;
+      if (c.max != null) return `${label}: ≤${c.max}`;
+      return label;
+    }
+    case "time_of_day": {
+      if (c.fromHour == null || c.toHour == null) return label;
+      return `${label}: ${c.fromHour}:00–${c.toHour}:59`;
+    }
     case "not_in_album":
       return label;
     case "not_in_specific_album":

--- a/src/lib/workflow/conditionBuilder.ts
+++ b/src/lib/workflow/conditionBuilder.ts
@@ -92,6 +92,63 @@ function buildSingleCondition(c: ICondition): SQL | undefined {
       return parts.length > 0 ? and(...parts)! : undefined;
     }
 
+    case "file_size": {
+      // min/max in megabytes (fractional allowed)
+      const parts: SQL[] = [];
+      if (c.min !== undefined && c.min !== null) parts.push(sql`${exif.fileSizeInByte} >= ${Math.round(c.min * 1048576)}`);
+      if (c.max !== undefined && c.max !== null) parts.push(sql`${exif.fileSizeInByte} <= ${Math.round(c.max * 1048576)}`);
+      return parts.length > 0 ? and(...parts)! : undefined;
+    }
+
+    case "filename": {
+      if (!c.text) return undefined;
+      const column = c.field === "path" ? assets.originalPath : assets.originalFileName;
+      // Escape LIKE wildcards so user text is matched literally
+      const escaped = c.text.replace(/([\\%_])/g, "\\$1");
+      const match = c.match || "contains";
+      const pattern =
+        match === "starts_with" ? `${escaped}%`
+        : match === "ends_with" ? `%${escaped}`
+        : `%${escaped}%`;
+      return match === "not_contains"
+        ? sql`${column} NOT ILIKE ${pattern}`
+        : sql`${column} ILIKE ${pattern}`;
+    }
+
+    case "file_extension": {
+      const raw: string = c.extensions || "";
+      const exts = raw
+        .split(",")
+        .map((e: string) => e.trim().replace(/^\./, "").toLowerCase())
+        .filter(Boolean);
+      if (exts.length === 0) return undefined;
+      // Extension = text after the last dot; files without one never match either mode
+      const extExpr = sql`lower(substring(${assets.originalFileName} from '\\.([^.]+)$'))`;
+      const list = exts.map((e: string) => `'${e.replace(/'/g, "''")}'`).join(",");
+      return c.match === "not_in"
+        ? sql`${extExpr} NOT IN (${sql.raw(list)})`
+        : sql`${extExpr} IN (${sql.raw(list)})`;
+    }
+
+    case "face_count": {
+      const faceCount = sql`(SELECT count(*) FROM "asset_face" af WHERE af."assetId" = ${assets.id} AND af."deletedAt" IS NULL AND af."isVisible" = true)`;
+      const parts: SQL[] = [];
+      if (c.min !== undefined && c.min !== null) parts.push(sql`${faceCount} >= ${c.min}`);
+      if (c.max !== undefined && c.max !== null) parts.push(sql`${faceCount} <= ${c.max}`);
+      return parts.length > 0 ? and(...parts)! : undefined;
+    }
+
+    case "time_of_day": {
+      if (c.fromHour == null || c.toHour == null) return undefined;
+      // localDateTime holds the capture wall-clock time, so no timezone math needed
+      const hour = sql`EXTRACT(HOUR FROM ${assets.localDateTime})`;
+      if (c.fromHour <= c.toHour) {
+        return sql`${hour} BETWEEN ${c.fromHour} AND ${c.toHour}`;
+      }
+      // From > To wraps past midnight, e.g. 22–5 = evening through early morning
+      return sql`(${hour} >= ${c.fromHour} OR ${hour} <= ${c.toHour})`;
+    }
+
     case "person": {
       const ids: string[] = c.personIds || (c.personId ? [c.personId] : []);
       if (ids.length === 0) return undefined;

--- a/src/types/workflow.d.ts
+++ b/src/types/workflow.d.ts
@@ -55,6 +55,8 @@ export type ConditionType =
   | "camera_make" | "camera_model" | "lens"
   | "asset_type" | "iso_range" | "focal_length"
   | "rating" | "is_favorited"
+  | "file_size" | "filename" | "file_extension"
+  | "face_count" | "time_of_day"
   | "not_in_album" | "not_in_specific_album";
 
 export interface ICondition {


### PR DESCRIPTION
## What

Adds five condition types for workflow IF/SWITCH nodes, covering the library-cleanup criteria common in other photo managers' smart-album systems (Apple Photos, Lightroom, Google Photos):

- **File Size** — min/max in MB (fractional allowed), over `asset_exif.fileSizeInByte`. The classic storage-cleanup filter.
- **File Name / Path** — contains / does not contain / starts with / ends with, against `originalFileName` or `originalPath` (`ILIKE`, with `%`/`_` escaped so user text matches literally). Catches `Screenshot_*`, `IMG-*-WA*` (WhatsApp), `FB_IMG_*`, etc.
- **File Extension** — is any of / is none of a comma-separated list (`png, gif, heic`), case-insensitive, matched after the last dot. Files without an extension never match either mode.
- **Face Count** — min/max detected faces (visible, non-soft-deleted `asset_face` rows). "How many people", complementing the person condition's "who": min 0/max 0 = no people (documents, landscapes), min 5 = group shots.
- **Time of Day** — from/to hour (0–23) over `localDateTime`, which stores the capture wall-clock time, so no timezone math is needed. From > To wraps past midnight (22 to 5 = evening through early morning), a natural sibling of Day of Week.

## Changes

Same shape as the existing conditions: cases in `conditionBuilder.ts`, field editors in `ConditionEditor.tsx`, node summaries in `conditionSummary.ts`, type-union entries. No new API routes, schema, or migrations; existing workflows are unaffected.

## Tested

On a live 26,063-asset library (Immich v3.0.1), each condition verified against ground-truth SQL:

| Condition | Ground truth | Workflow IF result |
|---|---|---|
| file size ≤ 0.3 MB | 210 | 210 → TRUE |
| name contains "DSC" | 4,099 | 4,099 → TRUE |
| extension any of "png, GIF" (messy input on purpose) | 4 | 4 → TRUE |
| faces ≥ 5 | 1,513 | 1,513 → TRUE |
| time of day 22–5 (midnight wrap) | 531 | 531 → TRUE |

`tsc --noEmit` clean for the touched files.

Sibling of #298 (tag condition) and #299 (resolution condition); independent of both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
