### PR TITLE
feat: Remove Tag workflow action to complement Add Tag

### DIFF
--- a/src/components/workflows/NodePalette.tsx
+++ b/src/components/workflows/NodePalette.tsx
@@ -27,6 +27,7 @@ const actionItems: PaletteItem[] = [
   { type: "action", subType: "unfavorite", label: "Unfavorite", icon: HeartOff, color: "text-purple-500" },
   { type: "action", subType: "archive", label: "Archive", icon: Archive, color: "text-purple-500" },
   { type: "action", subType: "tag", label: "Add Tag", icon: Tag, color: "text-purple-500" },
+  { type: "action", subType: "remove_tag", label: "Remove Tag", icon: Tag, color: "text-purple-500" },
 ];
 
 function PaletteGroup({ title, items }: { title: string; items: PaletteItem[] }) {

--- a/src/components/workflows/config/ActionConfig.tsx
+++ b/src/components/workflows/config/ActionConfig.tsx
@@ -115,7 +115,7 @@ export default function ActionConfig({ subType, config, onChange }: ActionConfig
     );
   }
 
-  if (subType === "tag") {
+  if (subType === "tag" || subType === "remove_tag") {
     return (
       <div className="space-y-2">
         <Label className="text-xs">Tag Name</Label>
@@ -125,6 +125,9 @@ export default function ActionConfig({ subType, config, onChange }: ActionConfig
           value={config.tagName || ""}
           onChange={(e) => onChange({ ...config, tagName: e.target.value })}
         />
+        {subType === "remove_tag" && (
+          <p className="text-[10px] text-muted-foreground">Removes this tag from matched assets. If the tag doesn&apos;t exist, nothing happens.</p>
+        )}
       </div>
     );
   }

--- a/src/components/workflows/nodes/ActionNode.tsx
+++ b/src/components/workflows/nodes/ActionNode.tsx
@@ -9,6 +9,7 @@ const actionIcons: Record<string, any> = {
   unfavorite: HeartOff,
   archive: Archive,
   tag: Tag,
+  remove_tag: Tag,
 };
 
 const actionLabels: Record<string, string> = {
@@ -19,6 +20,7 @@ const actionLabels: Record<string, string> = {
   unfavorite: "Unfavorite",
   archive: "Archive",
   tag: "Add Tag",
+  remove_tag: "Remove Tag",
 };
 
 export default function ActionNode({ data, selected }: NodeProps) {
@@ -42,7 +44,7 @@ export default function ActionNode({ data, selected }: NodeProps) {
           {(subType === "add_to_album" || subType === "remove_from_album") && config.albumName && (
             <p className="text-[10px] text-muted-foreground truncate max-w-[160px]">{config.albumName}</p>
           )}
-          {subType === "tag" && config.tagName && (
+          {(subType === "tag" || subType === "remove_tag") && config.tagName && (
             <p className="text-[10px] text-muted-foreground truncate max-w-[160px]">{config.tagName}</p>
           )}
         </div>

--- a/src/lib/workflow/actionExecutor.ts
+++ b/src/lib/workflow/actionExecutor.ts
@@ -6,7 +6,7 @@ import { exif } from "@/schema";
 import { assets } from "@/schema/assets.schema";
 import { person } from "@/schema/person.schema";
 import { assetFaces } from "@/schema/assetFaces.schema";
-import { eq, and, inArray, sql, desc } from "drizzle-orm";
+import { eq, and, inArray, desc } from "drizzle-orm";
 import { IUser } from "@/types/user";
 import { getUserHeaders } from "@/helpers/user.helper";
 
@@ -183,16 +183,15 @@ export async function executeAction(
     case "remove_tag": {
       if (!config.tagName) throw new Error("Tag name is required");
       try {
-        // Look up the tag by value (full path for nested tags) without creating it —
-        // removing a tag that doesn't exist is a no-op, not an error.
-        const result = await db.execute(
-          sql`SELECT id FROM "tag" WHERE "userId" = ${user.id} AND "value" = ${config.tagName} LIMIT 1`
-        );
-        const tagId = result.rows?.[0]?.id as string | undefined;
-        if (!tagId) {
+        // Look up the tag via Immich's API (same source of truth the "tag"
+        // action creates/gets from) without creating it — removing a tag
+        // that doesn't exist is a no-op, not an error.
+        const tags = await immichFetch("/tags", "GET", undefined, user);
+        const tag = Array.isArray(tags) ? tags.find((t: any) => t.value === config.tagName) : undefined;
+        if (!tag) {
           return { action: "remove_tag", assetsProcessed: 0 };
         }
-        await immichFetch(`/tags/${tagId}/assets`, "DELETE", { ids: assetIds }, user);
+        await immichFetch(`/tags/${tag.id}/assets`, "DELETE", { ids: assetIds }, user);
         return { action: "remove_tag", assetsProcessed: assetIds.length };
       } catch (e: any) {
         return { action: "remove_tag", assetsProcessed: 0, error: e.message };

--- a/src/lib/workflow/actionExecutor.ts
+++ b/src/lib/workflow/actionExecutor.ts
@@ -180,6 +180,25 @@ export async function executeAction(
       }
     }
 
+    case "remove_tag": {
+      if (!config.tagName) throw new Error("Tag name is required");
+      try {
+        // Look up the tag by value (full path for nested tags) without creating it —
+        // removing a tag that doesn't exist is a no-op, not an error.
+        const result = await db.execute(
+          sql`SELECT id FROM "tag" WHERE "userId" = ${user.id} AND "value" = ${config.tagName} LIMIT 1`
+        );
+        const tagId = result.rows?.[0]?.id as string | undefined;
+        if (!tagId) {
+          return { action: "remove_tag", assetsProcessed: 0 };
+        }
+        await immichFetch(`/tags/${tagId}/assets`, "DELETE", { ids: assetIds }, user);
+        return { action: "remove_tag", assetsProcessed: assetIds.length };
+      } catch (e: any) {
+        return { action: "remove_tag", assetsProcessed: 0, error: e.message };
+      }
+    }
+
     default:
       return { action: subType, assetsProcessed: 0, error: `Unknown action: ${subType}` };
   }

--- a/src/pages/workflows/[id]/runs/[runId].tsx
+++ b/src/pages/workflows/[id]/runs/[runId].tsx
@@ -135,11 +135,11 @@ function AnnotatedActionNode({ data }: NodeProps) {
   const step = data.runStep as any;
   const icons: Record<string, any> = {
     create_album: FolderPlus, add_to_album: FolderInput, remove_from_album: FolderMinus,
-    favorite: Heart, unfavorite: HeartOff, archive: Archive, tag: Tag,
+    favorite: Heart, unfavorite: HeartOff, archive: Archive, tag: Tag, remove_tag: Tag,
   };
   const labels: Record<string, string> = {
     create_album: "Create Album", add_to_album: "Add to Album", remove_from_album: "Remove from Album",
-    favorite: "Favorite", unfavorite: "Unfavorite", archive: "Archive", tag: "Add Tag",
+    favorite: "Favorite", unfavorite: "Unfavorite", archive: "Archive", tag: "Add Tag", remove_tag: "Remove Tag",
   };
   const Icon = icons[subType] || FolderPlus;
   const isDryRun = step?.detail?.includes("DRY RUN");


### PR DESCRIPTION
## What

Adds a **Remove Tag** workflow action to complement the existing Add Tag, so tag-based workflows can be fully bidirectional (e.g. keep a "needs-review" tag in sync as assets move in and out of a filtered set).

- Removes the configured tag from matched assets via `DELETE /tags/:id/assets`.
- The tag is looked up by name **without creating it** (Add Tag's `POST /tags` would create it as a side effect) — removing a tag that doesn't exist is a **no-op**, not an error, so add/remove pairs are safe in the same workflow.
- For nested tags, the name matches the tag's full path value (`Trips/2026`), same as what Add Tag creates at root level for simple names.

## Changes

- `actionExecutor.ts` — `remove_tag` case (tag lookup + bulk un-tag)
- `NodePalette.tsx`, `ActionNode.tsx`, run-detail view — "Remove Tag" entries
- `ActionConfig.tsx` — reuses the Add Tag name field, with a hint about the no-op behavior

## Tested

On a live library (Immich v3.0.1), against a 4-asset filtered set:

1. Add Tag `__rt_test` → 4 assets tagged (verified in `tag_asset`)
2. Remove Tag `__rt_test` → 0 tagged assets remain, run reports 4 processed
3. Remove Tag on a nonexistent name → run completes, 0 processed, no error

`tsc --noEmit` clean for the touched files.

Uses the same `tag.asset` permission as Add Tag's assign step — no permission-scope changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
