### PR TITLE
fix: exclude .env files from the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ npm-debug.log
 README.md
 .next
 .git
+.env
+.env.*.local


### PR DESCRIPTION
## Problem

`.dockerignore` does not list `.env`, so `docker build` copies any local
`.env` file into the build context. The Dockerfile's build stage does a broad
`COPY . .`, so a developer who builds the image with a populated `.env`
present bakes those secrets — API keys, DB credentials — into the image
layers. Anyone who can pull that image can extract them.

## Fix

Add `.env` and `.env.*.local` to `.dockerignore` so local environment files
never enter the build context.

This does not change how the app is configured at runtime: environment
variables are still supplied the intended way (via `docker run -e` / an
`env_file:` in compose), which is unaffected by `.dockerignore`. It only
stops build-time files from being embedded in the image.

## Testing

- `docker build` still succeeds with no `.env` present (unchanged path).
- With a `.env` present, it no longer appears in the build context /
  resulting image.
