### PR TITLE
feat: Rate & Cull — a Lightroom-style photo rating/culling tool

### DIFF
--- a/src/components/cull/ExifPanel.tsx
+++ b/src/components/cull/ExifPanel.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+
+import { getAssetExif, ICullExif } from "@/handlers/api/cull.handler";
+import { humanizeBytes } from "@/helpers/string.helper";
+
+/**
+ * EXIF summary overlay for the full-screen viewer — reuses the same
+ * /api/assets/[id]/detail endpoint AssetInfoPanel uses elsewhere in the app,
+ * fetched on demand (only while the panel is open for the current photo)
+ * rather than bloating the paginated cull-assets list with EXIF for photos
+ * that may never get their panel opened.
+ */
+export default function ExifPanel({ assetId }: { assetId: string }) {
+  const [data, setData] = useState<ICullExif | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setData(null);
+    setLoading(true);
+    getAssetExif(assetId)
+      .then((res) => { if (!cancelled) setData(res); })
+      .catch(() => { if (!cancelled) setData(null); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [assetId]);
+
+  const row = (label: string, value: React.ReactNode) =>
+    value != null && value !== "" ? (
+      <div className="flex justify-between gap-4">
+        <span className="text-white/50">{label}</span>
+        <span className="text-right">{value}</span>
+      </div>
+    ) : null;
+
+  const exposure = data && [
+    data.fNumber ? `f/${data.fNumber}` : null,
+    data.exposureTime || null,
+    data.iso ? `ISO ${data.iso}` : null,
+    data.focalLength ? `${data.focalLength}mm` : null,
+  ].filter(Boolean).join(" · ");
+
+  const location = data && [data.city, data.state, data.country].filter(Boolean).join(", ");
+
+  return (
+    <div
+      className="absolute right-3 top-14 z-20 w-72 rounded-lg bg-black/80 p-4 text-sm text-white shadow-lg backdrop-blur"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {loading ? (
+        <div className="flex justify-center py-4"><Loader2 size={18} className="animate-spin" /></div>
+      ) : !data ? (
+        <div className="text-white/50">Couldn&apos;t load EXIF data.</div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {row("Camera", [data.make, data.model].filter(Boolean).join(" "))}
+          {row("Lens", data.lensModel)}
+          {row("Exposure", exposure || null)}
+          {row("Dimensions", data.exifImageWidth && data.exifImageHeight ? `${data.exifImageWidth} × ${data.exifImageHeight}` : null)}
+          {row("File size", data.fileSizeInByte ? humanizeBytes(data.fileSizeInByte) : null)}
+          {row("Taken", data.dateTimeOriginal ? new Date(data.dateTimeOriginal).toLocaleString() : null)}
+          {row("Location", location || null)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/cull/HelpGuide.tsx
+++ b/src/components/cull/HelpGuide.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { HelpCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger,
+} from "@/components/ui/dialog";
+import { displayKey, ICullShortcutAction } from "@/lib/cull/shortcuts";
+
+const FIXED_SHORTCUTS: [string, string][] = [
+  ["1 – 5", "Set star rating (press the same number again to clear it)"],
+  ["0", "Clear star rating"],
+  ["← / →", "Previous / next photo (viewer)"],
+  ["Cmd/Ctrl+A", "Select every loaded photo (grid)"],
+  ["Esc", "Close viewer, or clear grid selection"],
+];
+
+const REMAPPABLE_ORDER: [ICullShortcutAction, string][] = [
+  ["pick", "Pick"],
+  ["reject", "Reject"],
+  ["unflag", "Unflag (clear pick/reject)"],
+  ["reviewed", "Toggle Reviewed"],
+  ["favorite", "Toggle Favorite"],
+  ["info", "Toggle EXIF info panel (viewer only)"],
+];
+
+/** "?" help dialog for Rate & Cull — shortcuts (reflecting the user's own remapping) plus a basic workflow. */
+export default function HelpGuide({ shortcuts }: { shortcuts: Record<ICullShortcutAction, string> }) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          size="sm" variant="ghost"
+          className="h-7 w-7 rounded-full border border-blue-500 p-0 text-blue-500 hover:bg-blue-500/10 hover:text-blue-500"
+          title="How Rate & Cull works"
+        >
+          <HelpCircle size={16} />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>How Rate & Cull works</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4 text-sm leading-relaxed">
+          <section>
+            <h3 className="font-semibold">Keyboard shortcuts</h3>
+            <p className="mt-1 text-muted-foreground">
+              Work on the open photo in the full-screen viewer, or on the current grid selection if
+              the viewer is closed. In the viewer, the toggle keys flip the photo&apos;s state; on a
+              multi-photo grid selection they mark everything — use the selection bar&apos;s buttons
+              to unmark in bulk. The six below are yours to remap (keyboard icon next to this one);
+              everything else is fixed.
+            </p>
+            <div className="mt-2 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 rounded-md border p-3">
+              {REMAPPABLE_ORDER.map(([action, desc]) => (
+                <React.Fragment key={action}>
+                  <span className="font-mono text-xs font-semibold">{displayKey(shortcuts[action])}</span>
+                  <span className="text-muted-foreground">{desc}</span>
+                </React.Fragment>
+              ))}
+              {FIXED_SHORTCUTS.map(([key, desc]) => (
+                <React.Fragment key={key}>
+                  <span className="font-mono text-xs font-semibold">{key}</span>
+                  <span className="text-muted-foreground">{desc}</span>
+                </React.Fragment>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h3 className="font-semibold">A basic culling pass</h3>
+            <p className="mt-1 text-muted-foreground">
+              A rhythm that works well for a big import: make a first, fast pass rejecting only the
+              obvious throwaways (blurry, eyes closed, duplicates) with{" "}
+              <strong>{displayKey(shortcuts.reject)}</strong> — don&apos;t rate or delete yet, just
+              reject. Then filter to <em>Unflagged</em> and do a second pass rating the keepers 1-5
+              with the number keys. Mark each photo <strong>Reviewed</strong> (
+              {displayKey(shortcuts.reviewed)}) as you finish deciding on it, so the default
+              Unreviewed filter always shows you exactly where you left off — useful across sessions
+              or if you get interrupted. Favorite ({displayKey(shortcuts.favorite)}) is separate from
+              rating — a quick way to flag standouts you want to find again fast, independent of the
+              star/pick/reject workflow. Only Archive and Trash actually change what&apos;s in your
+              library; rating, pick/reject, reviewed, and favorite are all just bookkeeping and are
+              always reversible.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="font-semibold">Pick/Reject/Reviewed are tags, not native fields</h3>
+            <p className="mt-1 text-muted-foreground">
+              They show up in Immich as tags nested under{" "}
+              <code className="rounded bg-muted px-1">ImmichPowerTools_CullandRate</code>, kept
+              deliberately separate from a rating so a photo can be, say, 4 stars <em>and</em>{" "}
+              rejected at the same time. You can view, rename, or clean these up any time in Tag
+              Manager.
+            </p>
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/cull/ShortcutSettings.tsx
+++ b/src/components/cull/ShortcutSettings.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from "react";
+import { Keyboard, RotateCcw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  CULL_SHORTCUT_LABELS, DEFAULT_CULL_SHORTCUTS, displayKey, ICullShortcutAction,
+  rebind, RESERVED_KEYS,
+} from "@/lib/cull/shortcuts";
+
+const ACTIONS = Object.keys(CULL_SHORTCUT_LABELS) as ICullShortcutAction[];
+
+/**
+ * "Remap" the six quick-action keys. Listens for the parent's controlled
+ * open state (rather than owning its own) so cull.tsx's global keydown
+ * handler can suppress itself while this dialog — or its "press a key…"
+ * capture — is open; otherwise a rebind keystroke would also fire the old
+ * shortcut underneath.
+ */
+export default function ShortcutSettings({
+  open,
+  onOpenChange,
+  shortcuts,
+  onChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  shortcuts: Record<ICullShortcutAction, string>;
+  onChange: (next: Record<ICullShortcutAction, string>) => void;
+}) {
+  const [listeningFor, setListeningFor] = useState<ICullShortcutAction | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) setListeningFor(null);
+  }, [open]);
+
+  useEffect(() => {
+    if (!listeningFor) return;
+    const handler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (["Shift", "Control", "Alt", "Meta"].includes(e.key)) return; // modifiers alone don't count
+      if (e.key === "Escape") { setListeningFor(null); return; }
+      if (e.metaKey || e.ctrlKey || e.altKey) {
+        setError("Shortcuts can't use Cmd/Ctrl/Alt combinations.");
+        return;
+      }
+      if (RESERVED_KEYS.has(e.key)) {
+        setError(`"${displayKey(e.key)}" is reserved for navigation and can't be reassigned.`);
+        return;
+      }
+      setError(null);
+      onChange(rebind(shortcuts, listeningFor, e.key));
+      setListeningFor(null);
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [listeningFor, shortcuts, onChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button
+          size="sm" variant="ghost"
+          className="h-7 w-7 rounded-full border border-muted-foreground/40 p-0 text-muted-foreground hover:bg-muted"
+          title="Customize keyboard shortcuts"
+        >
+          <Keyboard size={16} />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          Click a key, then press whatever you&apos;d rather use. If it&apos;s already taken, the
+          two swap. Rating (1-5, 0), the arrow keys, and Escape are fixed.
+        </p>
+        <div className="flex flex-col gap-1">
+          {ACTIONS.map((action) => (
+            <div key={action} className="flex items-center justify-between gap-3 rounded-md px-2 py-1.5 hover:bg-muted/50">
+              <span className="text-sm">{CULL_SHORTCUT_LABELS[action]}</span>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 min-w-[4.5rem] font-mono"
+                onClick={() => { setError(null); setListeningFor(action); }}
+              >
+                {listeningFor === action ? "Press a key…" : displayKey(shortcuts[action])}
+              </Button>
+            </div>
+          ))}
+        </div>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <Button
+          size="sm"
+          variant="ghost"
+          className="mt-1 w-fit gap-1.5 text-muted-foreground"
+          onClick={() => { onChange(DEFAULT_CULL_SHORTCUTS); setError(null); }}
+        >
+          <RotateCcw size={13} /> Reset to defaults
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/config/constants/cull.ts
+++ b/src/config/constants/cull.ts
@@ -1,0 +1,22 @@
+/**
+ * Pick/Reject/Reviewed flag tag names for the Cull tool, shared by the
+ * client handlers and the cull-assets API route. Flags are plain Immich tags
+ * kept independent of Immich's native star rating, because the rating field
+ * is a single overloaded value ([1-5 starred | -1 rejected | null]) and
+ * can't represent "4 stars AND rejected" at once. Tags also show up in
+ * Immich's own tag browser/search.
+ *
+ * Nested under a dedicated namespace tag (not flat top-level names) so they
+ * don't collide with a tag a user might create by hand — e.g. a household
+ * member's own "Reviewed" or "Picked" tag stays untouched and distinct from
+ * this tool's own bookkeeping tags.
+ *
+ * Previously flat "Picked"/"Rejected" (no namespace) — renamed 2026-07-06.
+ * Those old tags had zero tagged assets at rename time (verified), so there
+ * was nothing to migrate; they're harmless orphans a user can delete via Tag
+ * Manager if they want.
+ */
+export const CULL_TAG_NAMESPACE = "ImmichPowerTools_CullandRate";
+export const PICK_TAG_NAME = "IPT_Picked";
+export const REJECT_TAG_NAME = "IPT_Rejected";
+export const REVIEWED_TAG_NAME = "IPT_Reviewed";

--- a/src/config/constants/sidebarNavs.tsx
+++ b/src/config/constants/sidebarNavs.tsx
@@ -1,4 +1,4 @@
-import { Copy, GalleryHorizontal, GalleryVerticalEnd, Image as ImageIcon, MapPin, MapPinX, PackageSearch, Rewind, Search, Settings, Share2, User, Video, Workflow } from "lucide-react";
+import { Copy, GalleryHorizontal, GalleryVerticalEnd, Image as ImageIcon, MapPin, MapPinX, PackageSearch, Rewind, Search, Settings, Share2, Star, User, Video, Workflow } from "lucide-react";
 
 interface SidebarNav {
   title: string;
@@ -30,6 +30,7 @@ export const sidebarGroups: SidebarGroup[] = [
       { title: "Empty Videos", link: "/assets/empty-videos", icon: <Video className="h-4 w-4" /> },
       { title: "Bulk Duplicate Finder", link: "/assets/bulk-duplicate-finder", icon: <Copy className="h-4 w-4" /> },
       { title: "Orphan Finder", link: "/assets/orphan-finder", icon: <PackageSearch className="h-4 w-4" /> },
+      { title: "Rate & Cull", link: "/assets/cull", icon: <Star className="h-4 w-4" />, badge: "Beta" },
     ],
   },
   {

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -8,6 +8,11 @@ export const LOGOUT_PATH = BASE_API_ENDPOINT + "/users/logout";
 
 export const LIST_PEOPLE_PATH = BASE_API_ENDPOINT + "/people/list";
 export const LIST_TAGS_PATH = BASE_API_ENDPOINT + "/tags";
+// Create-or-get a tag by name, and assign that tag on assets — both proxied
+// straight to Immich with the requesting user's own session, same pattern as
+// UPDATE_ASSETS_PATH. Rate & Cull's Pick/Reject/Reviewed flags are Immich tags.
+export const CREATE_OR_GET_TAG_PATH = BASE_PROXY_ENDPOINT + "/tags";
+export const TAG_ASSETS_PATH = (tagId: string) => BASE_PROXY_ENDPOINT + "/tags/" + tagId + "/assets";
 export const SEARCH_PEOPLE_PATH = BASE_PROXY_ENDPOINT + "/search/person";
 export const SIMILAR_FACES_PATH = (id: string) => BASE_API_ENDPOINT + "/people/" + id + "/similar-faces";
 export const PERSON_THUBNAIL_PATH = (id: string) => BASE_PROXY_ENDPOINT + "/thumbnail/" + id;
@@ -48,6 +53,8 @@ export const ASSET_VIDEO_PATH = (id: string) => BASE_PROXY_ENDPOINT + "/asset/vi
 export const ASSET_GEO_HEATMAP_PATH = BASE_API_ENDPOINT + "/assets/geo-heatmap";
 export const LIST_EMPTY_VIDEOS_PATH = BASE_API_ENDPOINT + "/assets/empty-videos";
 export const LIST_ORPHAN_ASSETS_PATH = BASE_API_ENDPOINT + "/assets/orphan-finder";
+export const LIST_CULL_ASSETS_PATH = BASE_API_ENDPOINT + "/assets/cull-assets";
+export const ASSET_DETAIL_PATH = (id: string) => BASE_API_ENDPOINT + "/assets/" + id + "/detail";
 
 
 

--- a/src/handlers/api/asset.handler.ts
+++ b/src/handlers/api/asset.handler.ts
@@ -56,6 +56,10 @@ export interface IUpdateAssetsParams {
   dateTimeOriginal?: string;
   duplicateId?: string | null;
   isFavorite?: boolean;
+  /** Immich's native star rating: 1-5 (starred), -1 (rejected), or null (unrated). */
+  rating?: number | null;
+  /** Immich visibility: "archive" hides from the timeline (reversible), "timeline" restores. */
+  visibility?: "archive" | "timeline";
 }
 
 export const updateAssets = async (params: IUpdateAssetsParams) => {

--- a/src/handlers/api/cull.handler.ts
+++ b/src/handlers/api/cull.handler.ts
@@ -66,6 +66,8 @@ export interface ICullAsset extends IAsset {
 export type ICullRatingComparator = "lt" | "gt" | "eq";
 export type ICullPickStatus = "picked" | "rejected" | "unflagged";
 export type ICullReviewStatus = "reviewed" | "unreviewed";
+/** Immich stores `assets.type` as "IMAGE" | "VIDEO"; omitted = both. */
+export type ICullAssetTypeFilter = "IMAGE" | "VIDEO";
 
 export interface ICullAssetsParams {
   albumId?: string;
@@ -75,6 +77,7 @@ export interface ICullAssetsParams {
   ratingComparator?: ICullRatingComparator; // how ratingValue is applied; "eq" + no value = Unrated
   flag?: ICullPickStatus[]; // multi-select; empty/omitted = any
   reviewed?: ICullReviewStatus[]; // multi-select; empty or both = any
+  assetType?: ICullAssetTypeFilter; // omitted = photos and videos
   sortOrder?: "asc" | "desc";
   page?: number;
   limit?: number;

--- a/src/handlers/api/cull.handler.ts
+++ b/src/handlers/api/cull.handler.ts
@@ -1,0 +1,111 @@
+import {
+  ASSET_DETAIL_PATH, CREATE_OR_GET_TAG_PATH, LIST_CULL_ASSETS_PATH, TAG_ASSETS_PATH,
+} from "@/config/routes";
+import {
+  CULL_TAG_NAMESPACE, PICK_TAG_NAME, REJECT_TAG_NAME, REVIEWED_TAG_NAME,
+} from "@/config/constants/cull";
+import API from "@/lib/api";
+import { IAsset } from "@/types/asset";
+
+// Tag names live in config/constants/cull.ts (shared with the API route);
+// re-exported here so existing imports keep working.
+export { CULL_TAG_NAMESPACE, PICK_TAG_NAME, REJECT_TAG_NAME, REVIEWED_TAG_NAME } from "@/config/constants/cull";
+
+/**
+ * Immich's POST /tags does NOT upsert — it 400s with "A tag with that name
+ * already exists" once the tag exists. So a real get-or-create needs the
+ * list check first; this is not just an optimization. `parentPath`, when
+ * given, is prepended so the existence check matches on the tag's real full
+ * value (e.g. "Namespace/Leaf"), not just the leaf name — otherwise a nested
+ * tag would look "missing" forever and hit the same 400 on every retry.
+ */
+export const getOrCreateTag = async (
+  name: string,
+  parent?: { id: string; value: string }
+): Promise<{ id: string; value: string }> => {
+  const existing: { id: string; value: string }[] = await API.get(CREATE_OR_GET_TAG_PATH);
+  const fullPath = parent ? `${parent.value}/${name}` : name;
+  const found = existing.find((t) => t.value === fullPath);
+  if (found) return found;
+  return API.post(CREATE_OR_GET_TAG_PATH, { name, parentId: parent?.id });
+};
+
+/**
+ * Get-or-create all three of this tool's flag tags under the namespace tag.
+ * The namespace MUST be resolved once before the children are created in
+ * parallel: three concurrent get-or-creates of the same namespace all see it
+ * missing on a fresh install, all POST it, and two get 400 "already exists" —
+ * breaking flag setup until the next page load. The children are distinct
+ * names, so creating them concurrently is safe.
+ */
+export const ensureCullTags = async (): Promise<{ pick: string; reject: string; reviewed: string }> => {
+  const namespace = await getOrCreateTag(CULL_TAG_NAMESPACE);
+  const [p, r, rv] = await Promise.all([
+    getOrCreateTag(PICK_TAG_NAME, namespace),
+    getOrCreateTag(REJECT_TAG_NAME, namespace),
+    getOrCreateTag(REVIEWED_TAG_NAME, namespace),
+  ]);
+  return { pick: p.id, reject: r.id, reviewed: rv.id };
+};
+
+export const addTagToAssets = (tagId: string, assetIds: string[]) =>
+  API.put(TAG_ASSETS_PATH(tagId), { ids: assetIds });
+
+export const removeTagFromAssets = (tagId: string, assetIds: string[]) =>
+  API.delete(TAG_ASSETS_PATH(tagId), { ids: assetIds });
+
+/** An asset in the cull feed, carrying its persisted rating + flag state. */
+export interface ICullAsset extends IAsset {
+  rating: number | null; // 1-5, null = unrated (0 normalized to null server-side)
+  picked: boolean;
+  rejected: boolean;
+  reviewed: boolean;
+  isFavorite: boolean;
+}
+
+export type ICullRatingComparator = "lt" | "gt" | "eq";
+export type ICullPickStatus = "picked" | "rejected" | "unflagged";
+export type ICullReviewStatus = "reviewed" | "unreviewed";
+
+export interface ICullAssetsParams {
+  albumId?: string;
+  startDate?: string; // yyyy-MM-dd, camera-local
+  endDate?: string;
+  ratingValue?: number | null; // 1-5 stars; null/omitted = no star selected
+  ratingComparator?: ICullRatingComparator; // how ratingValue is applied; "eq" + no value = Unrated
+  flag?: ICullPickStatus[]; // multi-select; empty/omitted = any
+  reviewed?: ICullReviewStatus[]; // multi-select; empty or both = any
+  sortOrder?: "asc" | "desc";
+  page?: number;
+  limit?: number;
+}
+
+export const listCullAssets = (
+  params: ICullAssetsParams
+): Promise<{ assets: ICullAsset[]; total: number; hasNext: boolean }> =>
+  API.get(LIST_CULL_ASSETS_PATH, {
+    ...params,
+    ratingValue: params.ratingValue ?? undefined,
+    flag: params.flag?.length ? params.flag.join(",") : undefined,
+    reviewed: params.reviewed?.length ? params.reviewed.join(",") : undefined,
+  });
+
+/** Slim EXIF summary for the viewer's info panel — reuses the same endpoint AssetInfoPanel uses. */
+export interface ICullExif {
+  make: string | null;
+  model: string | null;
+  lensModel: string | null;
+  fNumber: number | null;
+  focalLength: number | null;
+  iso: number | null;
+  exposureTime: string | null;
+  fileSizeInByte: number | null;
+  exifImageWidth: number | null;
+  exifImageHeight: number | null;
+  dateTimeOriginal: string | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
+}
+
+export const getAssetExif = (assetId: string): Promise<ICullExif> => API.get(ASSET_DETAIL_PATH(assetId));

--- a/src/lib/cull/shortcuts.ts
+++ b/src/lib/cull/shortcuts.ts
@@ -1,0 +1,71 @@
+/**
+ * User-remappable keyboard shortcuts for Rate & Cull's quick actions.
+ * Rating (1-5, 0) and navigation (arrows, Escape) stay fixed — they're
+ * either inherently numeric or near-universal conventions not worth
+ * customizing. Stored per-browser in localStorage (same pattern as the
+ * app's other per-device UI preferences, e.g. AssetGrid's info-panel-open
+ * flag), not synced to the account — there's no per-user settings backend
+ * for this app to hang it on.
+ */
+export type ICullShortcutAction = "pick" | "reject" | "unflag" | "reviewed" | "favorite" | "info";
+
+export const CULL_SHORTCUT_LABELS: Record<ICullShortcutAction, string> = {
+  pick: "Pick",
+  reject: "Reject",
+  unflag: "Unflag (clear pick/reject)",
+  reviewed: "Toggle Reviewed",
+  favorite: "Toggle Favorite",
+  info: "Toggle EXIF info panel (viewer only)",
+};
+
+export const DEFAULT_CULL_SHORTCUTS: Record<ICullShortcutAction, string> = {
+  pick: "p",
+  reject: "x",
+  unflag: "u",
+  reviewed: "r",
+  favorite: "f",
+  info: "i",
+};
+
+/** Keys a shortcut can't be rebound to — reserved by fixed, non-remappable behavior. */
+export const RESERVED_KEYS = new Set(["Escape", "ArrowLeft", "ArrowRight", "Tab"]);
+
+const STORAGE_KEY = "cullShortcuts";
+
+export function loadCullShortcuts(): Record<ICullShortcutAction, string> {
+  if (typeof window === "undefined") return DEFAULT_CULL_SHORTCUTS;
+  try {
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+    return { ...DEFAULT_CULL_SHORTCUTS, ...saved };
+  } catch {
+    return DEFAULT_CULL_SHORTCUTS;
+  }
+}
+
+export function saveCullShortcuts(map: Record<ICullShortcutAction, string>) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+}
+
+/**
+ * Assign `key` to `action`. If another action already owns that key, the two
+ * swap — every action always keeps exactly one key, so nothing is ever left
+ * unbound and no key ever maps to two actions at once.
+ */
+export function rebind(
+  map: Record<ICullShortcutAction, string>,
+  action: ICullShortcutAction,
+  key: string
+): Record<ICullShortcutAction, string> {
+  const oldKey = map[action];
+  const conflict = (Object.keys(map) as ICullShortcutAction[]).find(
+    (a) => a !== action && map[a].toLowerCase() === key.toLowerCase()
+  );
+  const next = { ...map, [action]: key };
+  if (conflict) next[conflict] = oldKey;
+  return next;
+}
+
+export const keyMatches = (e: KeyboardEvent, key: string) => e.key.toLowerCase() === key.toLowerCase();
+
+/** Display form for a bound key, e.g. "p" -> "P", " " -> "Space". */
+export const displayKey = (key: string) => (key === " " ? "Space" : key.length === 1 ? key.toUpperCase() : key);

--- a/src/pages/api/assets/cull-assets.ts
+++ b/src/pages/api/assets/cull-assets.ts
@@ -1,0 +1,153 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { and, asc, desc, eq, gt, gte, isNull, lt, or, sql } from "drizzle-orm";
+
+import { db } from "@/config/db";
+import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
+import { isFlipped } from "@/helpers/asset.helper";
+import { assets, exif, tags } from "@/schema";
+import { CULL_TAG_NAMESPACE, PICK_TAG_NAME, REJECT_TAG_NAME, REVIEWED_TAG_NAME } from "@/config/constants/cull";
+
+/**
+ * Paginated asset feed for the Cull tool.
+ *
+ * Sources (mutually combinable): whole library (no params), album
+ * (albumId), or capture-date range (startDate/endDate, on the camera-local
+ * localDateTime like the album/potential-albums routes).
+ *
+ * Filters: star rating (exif.rating — Immich's native field; 0 is treated as
+ * unrated, it's invalid as a rating since v3) via a value + comparator
+ * (</>/=; no value + "=" means Unrated), pick status (Picked/Rejected tags —
+ * see cull.handler.ts for why flags are tags and not the rating's -1 value,
+ * multi-select), and reviewed state (a third, independent tag — not tied to
+ * pick/reject, also multi-select).
+ *
+ * Server-side pagination is the point: the previous client fetched EVERY
+ * page of an album before showing photo #1, which is exactly the slow-large-
+ * album problem. Each row also carries rating + picked/rejected/reviewed/
+ * favorite so the UI can render true persisted state in overlays/badges
+ * without extra calls.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser) return res.status(401).json({ message: "Unauthorized" });
+
+  const {
+    albumId,
+    startDate,
+    endDate,
+    ratingValue,
+    ratingComparator = "gt", // "lt" | "gt" | "eq" — how ratingValue is applied; "eq" with no value means Unrated
+    flag = "", // comma-separated ICullPickStatus[]; empty = any
+    reviewed = "", // comma-separated ICullReviewStatus[]; empty or both = any
+    sortOrder = "desc",
+    page = "1",
+    limit = "200",
+  } = req.query as Record<string, string>;
+
+  const limitNum = Math.min(parseInt(limit, 10) || 200, 500);
+  const pageNum = Math.max(parseInt(page, 10) || 1, 1);
+
+  // Resolve the user's Pick/Reject/Reviewed tag ids once (they may not exist
+  // yet if nothing has ever been flagged — that's fine, EXISTS just goes
+  // false). These are nested under CULL_TAG_NAMESPACE, so match on full value.
+  const pickPath = `${CULL_TAG_NAMESPACE}/${PICK_TAG_NAME}`;
+  const rejectPath = `${CULL_TAG_NAMESPACE}/${REJECT_TAG_NAME}`;
+  const reviewedPath = `${CULL_TAG_NAMESPACE}/${REVIEWED_TAG_NAME}`;
+  const tagRows = await db
+    .select({ id: tags.id, value: tags.value })
+    .from(tags)
+    .where(and(eq(tags.userId, currentUser.id), sql`${tags.value} IN (${pickPath}, ${rejectPath}, ${reviewedPath})`));
+  const pickTagId = tagRows.find((t) => t.value === pickPath)?.id ?? null;
+  const rejectTagId = tagRows.find((t) => t.value === rejectPath)?.id ?? null;
+  const reviewedTagId = tagRows.find((t) => t.value === reviewedPath)?.id ?? null;
+
+  const taggedWith = (tagId: string) =>
+    sql`EXISTS (SELECT 1 FROM "tag_asset" ta WHERE ta."assetId" = ${assets.id} AND ta."tagId" = ${tagId})`;
+  const pickedExpr = pickTagId ? taggedWith(pickTagId) : sql`false`;
+  const rejectedExpr = rejectTagId ? taggedWith(rejectTagId) : sql`false`;
+  const reviewedExpr = reviewedTagId ? taggedWith(reviewedTagId) : sql`false`;
+
+  const conditions: any[] = [
+    eq(assets.ownerId, currentUser.id),
+    eq(assets.visibility, "timeline"),
+    eq(assets.status, "active"),
+    isNull(assets.deletedAt),
+  ];
+
+  if (albumId) {
+    conditions.push(
+      sql`EXISTS (SELECT 1 FROM "album_asset" aa WHERE aa."assetId" = ${assets.id} AND aa."albumId" = ${albumId})`
+    );
+  }
+  if (startDate) conditions.push(gte(assets.localDateTime, new Date(`${startDate}T00:00:00`)));
+  if (endDate) {
+    const endExclusive = new Date(`${endDate}T00:00:00`);
+    endExclusive.setDate(endExclusive.getDate() + 1);
+    conditions.push(lt(assets.localDateTime, endExclusive));
+  }
+
+  const ratingValueNum = ratingValue ? parseInt(ratingValue, 10) : null;
+  if (ratingValueNum === null) {
+    // No star selected: "=" reads as Unrated, "<"/">" mean no constraint (any).
+    if (ratingComparator === "eq") conditions.push(sql`(${exif.rating} IS NULL OR ${exif.rating} <= 0)`);
+  } else if (ratingValueNum >= 1 && ratingValueNum <= 5) {
+    if (ratingComparator === "eq") conditions.push(eq(exif.rating, ratingValueNum));
+    else if (ratingComparator === "lt") conditions.push(lt(exif.rating, ratingValueNum));
+    else conditions.push(gt(exif.rating, ratingValueNum));
+  }
+
+  const flagValues = flag.split(",").filter(Boolean);
+  if (flagValues.length && flagValues.length < 3) {
+    conditions.push(
+      or(
+        ...flagValues.map((f) =>
+          f === "picked" ? pickedExpr : f === "rejected" ? rejectedExpr : sql`(NOT ${pickedExpr} AND NOT ${rejectedExpr})`
+        )
+      )!
+    );
+  }
+
+  const reviewedValues = reviewed.split(",").filter(Boolean);
+  if (reviewedValues.length === 1) {
+    conditions.push(reviewedValues[0] === "reviewed" ? reviewedExpr : sql`NOT ${reviewedExpr}`);
+  }
+
+  const rows = await db
+    .select({
+      id: assets.id,
+      type: assets.type,
+      ownerId: assets.ownerId,
+      isFavorite: assets.isFavorite,
+      duration: assets.duration,
+      originalFileName: assets.originalFileName,
+      localDateTime: assets.localDateTime,
+      exifImageWidth: exif.exifImageWidth,
+      exifImageHeight: exif.exifImageHeight,
+      orientation: exif.orientation,
+      rating: exif.rating,
+      picked: sql<boolean>`${pickedExpr}`,
+      rejected: sql<boolean>`${rejectedExpr}`,
+      reviewed: sql<boolean>`${reviewedExpr}`,
+      total: sql<number>`COUNT(*) OVER()::int`,
+    })
+    .from(assets)
+    .leftJoin(exif, eq(exif.assetId, assets.id))
+    .where(and(...conditions))
+    .orderBy(
+      sortOrder === "asc" ? asc(assets.localDateTime) : desc(assets.localDateTime),
+      asc(assets.id)
+    )
+    .limit(limitNum)
+    .offset((pageNum - 1) * limitNum);
+
+  const total = rows.length ? Number(rows[0].total) : 0;
+  const cleaned = rows.map(({ total: _t, ...a }) => ({
+    ...a,
+    exifImageWidth: isFlipped(a.orientation) ? a.exifImageHeight : a.exifImageWidth,
+    exifImageHeight: isFlipped(a.orientation) ? a.exifImageWidth : a.exifImageHeight,
+    // Normalize legacy 0 ratings to null so the UI has one "unrated" state.
+    rating: a.rating && a.rating > 0 ? a.rating : null,
+  }));
+
+  return res.status(200).json({ assets: cleaned, total, hasNext: pageNum * limitNum < total });
+}

--- a/src/pages/api/assets/cull-assets.ts
+++ b/src/pages/api/assets/cull-assets.ts
@@ -18,8 +18,9 @@ import { CULL_TAG_NAMESPACE, PICK_TAG_NAME, REJECT_TAG_NAME, REVIEWED_TAG_NAME }
  * unrated, it's invalid as a rating since v3) via a value + comparator
  * (</>/=; no value + "=" means Unrated), pick status (Picked/Rejected tags —
  * see cull.handler.ts for why flags are tags and not the rating's -1 value,
- * multi-select), and reviewed state (a third, independent tag — not tied to
- * pick/reject, also multi-select).
+ * multi-select), reviewed state (a third, independent tag — not tied to
+ * pick/reject, also multi-select), and asset type (IMAGE/VIDEO; omitted =
+ * both).
  *
  * Server-side pagination is the point: the previous client fetched EVERY
  * page of an album before showing photo #1, which is exactly the slow-large-
@@ -39,6 +40,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     ratingComparator = "gt", // "lt" | "gt" | "eq" — how ratingValue is applied; "eq" with no value means Unrated
     flag = "", // comma-separated ICullPickStatus[]; empty = any
     reviewed = "", // comma-separated ICullReviewStatus[]; empty or both = any
+    assetType = "", // "IMAGE" | "VIDEO"; empty = both
     sortOrder = "desc",
     page = "1",
     limit = "200",
@@ -79,6 +81,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       sql`EXISTS (SELECT 1 FROM "album_asset" aa WHERE aa."assetId" = ${assets.id} AND aa."albumId" = ${albumId})`
     );
   }
+  // Allowlisted rather than passed through: `type` is a bare varchar, so an
+  // arbitrary value would silently return an empty feed rather than an error.
+  if (assetType === "IMAGE" || assetType === "VIDEO") conditions.push(eq(assets.type, assetType));
+
   if (startDate) conditions.push(gte(assets.localDateTime, new Date(`${startDate}T00:00:00`)));
   if (endDate) {
     const endExclusive = new Date(`${endDate}T00:00:00`);

--- a/src/pages/assets/cull.tsx
+++ b/src/pages/assets/cull.tsx
@@ -3,7 +3,7 @@ import "react-photo-album/rows.css";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Archive, CheckCircle2, ChevronLeft, ChevronRight, Circle, ExternalLink, Filter, Glasses, Heart,
-  Info, Loader2, SortAsc, SortDesc, Star, Trash2, X, XCircle,
+  Image as ImageIcon, Info, Layers, Loader2, SortAsc, SortDesc, Star, Trash2, Video, X, XCircle,
 } from "lucide-react";
 import { RowsPhotoAlbum } from "react-photo-album";
 import type { RenderImageContext, RenderImageProps } from "react-photo-album";
@@ -31,6 +31,7 @@ import {
   addTagToAssets, ensureCullTags, ICullAsset, ICullPickStatus, ICullRatingComparator,
   ICullReviewStatus, listCullAssets, removeTagFromAssets,
 } from "@/handlers/api/cull.handler";
+import { cn } from "@/lib/utils";
 import { ASSET_PREVIEW_PATH, ASSET_THUMBNAIL_PATH, ASSET_VIDEO_PATH } from "@/config/routes";
 import {
   displayKey, ICullShortcutAction, keyMatches, loadCullShortcuts, saveCullShortcuts,
@@ -41,6 +42,9 @@ const PAGE_SIZE = 200;
 
 type ISourceMode = "library" | "album" | "range";
 type IFlag = "pick" | "reject" | null;
+
+/** Asset-type filter — `assets.type` is "IMAGE" | "VIDEO" in Immich. */
+type ICullAssetType = "all" | "IMAGE" | "VIDEO";
 
 const isTypingTarget = (el: EventTarget | null) => {
   const tag = (el as HTMLElement)?.tagName;
@@ -118,6 +122,7 @@ export default function CullPhotosPage() {
   // Defaults to "unreviewed" (unlike the other filters) so the queue always
   // opens on wherever you left off reviewing.
   const [reviewStatusFilter, setReviewStatusFilter] = useState<Set<ICullReviewStatus>>(new Set(["unreviewed"]));
+  const [assetTypeFilter, setAssetTypeFilter] = useState<ICullAssetType>("all");
   const [sortOrder, setSortOrder] = useState<"desc" | "asc">("desc");
   const { exImmichUrl } = useConfig();
   // Full-screen viewer's bottom control chips key off the site theme (the
@@ -193,6 +198,7 @@ export default function CullPhotosPage() {
           ratingComparator,
           flag: Array.from(pickStatusFilter),
           reviewed: Array.from(reviewStatusFilter),
+          assetType: assetTypeFilter === "all" ? undefined : assetTypeFilter,
           sortOrder,
           page,
           limit: PAGE_SIZE,
@@ -207,7 +213,7 @@ export default function CullPhotosPage() {
         reset ? setLoading(false) : setLoadingMore(false);
       }
     },
-    [sourceParams, ratingValue, ratingComparator, pickStatusFilter, reviewStatusFilter, sortOrder]
+    [sourceParams, ratingValue, ratingComparator, pickStatusFilter, reviewStatusFilter, assetTypeFilter, sortOrder]
   );
 
   // Any source/filter change restarts from page 1 (server does the filtering).
@@ -576,11 +582,15 @@ export default function CullPhotosPage() {
         }
       />
       <div className="flex flex-col gap-3 p-4">
-        {/* source + filter row */}
-        <div className="flex flex-wrap items-center gap-2">
+        {/* Source + filter row. Sticky so it stays put while the grid scrolls;
+            the negative margins bleed the opaque background over the wrapper's
+            p-4 padding, and `top-0` pins it to the top of PageLayout's scroll
+            area. Sizing here follows the app defaults (h-9, 16px icons) to
+            match the original modules. */}
+        <div className="sticky top-0 z-20 -mx-4 -mt-4 flex flex-wrap items-center gap-2 border-b bg-background/95 px-4 pb-3 pt-4 backdrop-blur-sm">
           <label className="text-sm text-muted-foreground">Review</label>
           <Select value={mode} onValueChange={(v) => setMode(v as ISourceMode)}>
-            <SelectTrigger className="w-40 h-8"><SelectValue /></SelectTrigger>
+            <SelectTrigger className="w-40"><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectItem value="library">Whole library</SelectItem>
               <SelectItem value="album">Album</SelectItem>
@@ -589,7 +599,7 @@ export default function CullPhotosPage() {
           </Select>
           {mode === "album" && (
             <Select value={albumId} onValueChange={setAlbumId}>
-              <SelectTrigger className="w-72 h-8"><SelectValue placeholder="Choose an album…" /></SelectTrigger>
+              <SelectTrigger className="w-72"><SelectValue placeholder="Choose an album…" /></SelectTrigger>
               <SelectContent>
                 {albums.map((a) => (
                   <SelectItem key={a.id} value={a.id}>{a.albumName} ({a.assetCount})</SelectItem>
@@ -599,12 +609,12 @@ export default function CullPhotosPage() {
           )}
           {mode === "range" && (
             <>
-              <Input type="date" className="h-8 w-40" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
+              <Input type="date" className="w-40" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
               <span className="text-sm text-muted-foreground">to</span>
-              <Input type="date" className="h-8 w-40" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
+              <Input type="date" className="w-40" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
               {DATE_PRESETS.map((p) => (
                 <Button
-                  key={p.label} size="sm" variant="ghost" className="h-8 px-2 text-xs"
+                  key={p.label} variant="ghost" className="px-2 text-xs"
                   onClick={() => { const [s, en] = p.range(); setStartDate(s); setEndDate(en); }}
                 >
                   {p.label}
@@ -613,7 +623,7 @@ export default function CullPhotosPage() {
             </>
           )}
           <Button
-            size="sm" variant="outline" className="h-8"
+            variant="outline"
             title="Select every loaded photo (Cmd/Ctrl+A)"
             disabled={!assets.length || selectedIds.length === assets.length}
             onClick={() => setSelectedIds(assets.map((a) => a.id))}
@@ -621,7 +631,7 @@ export default function CullPhotosPage() {
             Select all
           </Button>
           <Button
-            size="sm" variant="outline" className="h-8"
+            variant="outline"
             title="Deselect all (Esc)"
             disabled={!selectedIds.length}
             onClick={() => setSelectedIds([])}
@@ -630,33 +640,54 @@ export default function CullPhotosPage() {
           </Button>
           <div className="ml-auto flex flex-wrap items-center gap-2">
             <span className="flex items-center gap-1 text-sm text-muted-foreground">
-              <Filter size={14} /> Filters
+              <Filter size={16} /> Filters
             </span>
+            {/* Asset type — single-select: All / Photos / Videos */}
+            <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+              {([
+                { v: "all", title: "All", Icon: Layers },
+                { v: "IMAGE", title: "Photos only", Icon: ImageIcon },
+                { v: "VIDEO", title: "Videos only", Icon: Video },
+              ] as { v: ICullAssetType; title: string; Icon: typeof Layers }[]).map(({ v, title, Icon }) => (
+                <button
+                  key={v}
+                  type="button"
+                  title={title}
+                  className={cn(
+                    "rounded p-2",
+                    assetTypeFilter === v ? "bg-foreground text-background" : "text-muted-foreground hover:bg-accent"
+                  )}
+                  onClick={() => setAssetTypeFilter(v)}
+                >
+                  <Icon size={16} />
+                </button>
+              ))}
+            </div>
             {/* Pick status — multi-select */}
             <div className="flex items-center gap-0.5 rounded-md border p-0.5">
               <button
                 type="button"
                 title="Picked"
-                className={`rounded p-1.5 ${pickStatusFilter.has("picked") ? "bg-emerald-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
+                className={`rounded p-2 ${pickStatusFilter.has("picked") ? "bg-emerald-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
                 onClick={() => togglePickStatus("picked")}
               >
-                <CheckCircle2 size={15} />
+                <CheckCircle2 size={16} />
               </button>
               <button
                 type="button"
                 title="Rejected"
-                className={`rounded p-1.5 ${pickStatusFilter.has("rejected") ? "bg-red-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
+                className={`rounded p-2 ${pickStatusFilter.has("rejected") ? "bg-red-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
                 onClick={() => togglePickStatus("rejected")}
               >
-                <XCircle size={15} />
+                <XCircle size={16} />
               </button>
               <button
                 type="button"
                 title="Unflagged"
-                className={`rounded p-1.5 ${pickStatusFilter.has("unflagged") ? "bg-slate-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
+                className={`rounded p-2 ${pickStatusFilter.has("unflagged") ? "bg-slate-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
                 onClick={() => togglePickStatus("unflagged")}
               >
-                <Circle size={15} />
+                <Circle size={16} />
               </button>
             </div>
 
@@ -670,7 +701,7 @@ export default function CullPhotosPage() {
               >
                 {ratingComparator === "eq" ? "=" : ratingComparator === "gt" ? ">" : "<"}
               </button>
-              <StarRow value={ratingValue} size={16} onRate={setRatingValue} mutedClassName="text-muted-foreground/40" />
+              <StarRow value={ratingValue} size={18} onRate={setRatingValue} mutedClassName="text-muted-foreground/40" />
             </div>
 
             {/* Review status — multi-select */}
@@ -678,25 +709,24 @@ export default function CullPhotosPage() {
               <button
                 type="button"
                 title="Reviewed"
-                className={`rounded p-1.5 ${reviewStatusFilter.has("reviewed") ? "bg-sky-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
+                className={`rounded p-2 ${reviewStatusFilter.has("reviewed") ? "bg-sky-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
                 onClick={() => toggleReviewStatus("reviewed")}
               >
-                <Glasses size={15} />
+                <Glasses size={16} />
               </button>
               <button
                 type="button"
                 title="Unreviewed"
-                className={`rounded p-1.5 ${reviewStatusFilter.has("unreviewed") ? "bg-slate-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
+                className={`rounded p-2 ${reviewStatusFilter.has("unreviewed") ? "bg-slate-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
                 onClick={() => toggleReviewStatus("unreviewed")}
               >
-                <GlassesOff size={15} />
+                <GlassesOff size={16} />
               </button>
             </div>
 
             {/* Sort direction */}
             <Button
               variant="default"
-              size="sm"
               title={sortOrder === "asc" ? "Oldest first" : "Newest first"}
               onClick={() => setSortOrder(sortOrder === "asc" ? "desc" : "asc")}
             >

--- a/src/pages/assets/cull.tsx
+++ b/src/pages/assets/cull.tsx
@@ -1,0 +1,1012 @@
+import "react-photo-album/rows.css";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Archive, CheckCircle2, ChevronLeft, ChevronRight, Circle, ExternalLink, Filter, Glasses, Heart,
+  Info, Loader2, SortAsc, SortDesc, Star, Trash2, X, XCircle,
+} from "lucide-react";
+import { RowsPhotoAlbum } from "react-photo-album";
+import type { RenderImageContext, RenderImageProps } from "react-photo-album";
+import { useTheme } from "next-themes";
+
+import ExifPanel from "@/components/cull/ExifPanel";
+import HelpGuide from "@/components/cull/HelpGuide";
+import ShortcutSettings from "@/components/cull/ShortcutSettings";
+import PageLayout from "@/components/layouts/PageLayout";
+import type { AssetPhoto } from "@/components/shared/AssetGrid";
+import FloatingBar from "@/components/shared/FloatingBar";
+import Header from "@/components/shared/Header";
+import { AlertDialog } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import LazyGridImage from "@/components/ui/lazy-grid-image";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/components/ui/use-toast";
+import { useConfig } from "@/contexts/ConfigContext";
+import { listAlbums } from "@/handlers/api/album.handler";
+import { deleteAssets, updateAssets } from "@/handlers/api/asset.handler";
+import {
+  addTagToAssets, ensureCullTags, ICullAsset, ICullPickStatus, ICullRatingComparator,
+  ICullReviewStatus, listCullAssets, removeTagFromAssets,
+} from "@/handlers/api/cull.handler";
+import { ASSET_PREVIEW_PATH, ASSET_THUMBNAIL_PATH, ASSET_VIDEO_PATH } from "@/config/routes";
+import {
+  displayKey, ICullShortcutAction, keyMatches, loadCullShortcuts, saveCullShortcuts,
+} from "@/lib/cull/shortcuts";
+import { IAlbum } from "@/types/album";
+
+const PAGE_SIZE = 200;
+
+type ISourceMode = "library" | "album" | "range";
+type IFlag = "pick" | "reject" | null;
+
+const isTypingTarget = (el: EventTarget | null) => {
+  const tag = (el as HTMLElement)?.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || (el as HTMLElement)?.isContentEditable;
+};
+
+const fmtLocalDate = (d: Date) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+const daysAgo = (n: number) => {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d;
+};
+
+const DATE_PRESETS: { label: string; range: () => [string, string] }[] = [
+  { label: "Today", range: () => [fmtLocalDate(new Date()), fmtLocalDate(new Date())] },
+  { label: "Last 7 days", range: () => [fmtLocalDate(daysAgo(6)), fmtLocalDate(new Date())] },
+  { label: "Last 30 days", range: () => [fmtLocalDate(daysAgo(29)), fmtLocalDate(new Date())] },
+  {
+    label: "This month",
+    range: () => {
+      const now = new Date();
+      return [fmtLocalDate(new Date(now.getFullYear(), now.getMonth(), 1)), fmtLocalDate(now)];
+    },
+  },
+];
+
+// lucide-react has no "GlassesOff" icon — built the same way lucide draws its
+// own Off icons (base shape + a diagonal slash, here reusing EyeOff's "m2 2 20 20").
+const GlassesOff = ({ size = 15, className = "" }: { size?: number; className?: string }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    <circle cx="6" cy="15" r="4" />
+    <circle cx="18" cy="15" r="4" />
+    <path d="M14 15a2 2 0 0 0-2-2 2 2 0 0 0-2 2" />
+    <path d="M2.5 13 5 7c.7-1.3 1.4-2 3-2" />
+    <path d="M21.5 13 19 7c-.7-1.3-1.5-2-3-2" />
+    <path d="m2 2 20 20" />
+  </svg>
+);
+
+/**
+ * Lightroom-style culling: pick a source (whole library / album / date
+ * range), filter by rating/flag, rip through photos full-screen with
+ * keyboard shortcuts, or multi-select in the grid for bulk actions.
+ *
+ * Ratings (1-5) write Immich's native exif rating; Pick/Reject are Immich
+ * tags (see config/constants/cull.ts for why). Delete goes to Immich's
+ * TRASH (reversible for 30 days by default), never a hard delete. Archive
+ * sets visibility=archive (also reversible in Immich).
+ *
+ * Server-side pagination + neighbor prefetching are what make big albums
+ * and whole-library culling fast — nothing loads more than a page at once.
+ */
+export default function CullPhotosPage() {
+  // --- source & filters ---
+  const [mode, setMode] = useState<ISourceMode>("library");
+  const [albums, setAlbums] = useState<IAlbum[]>([]);
+  const [albumId, setAlbumId] = useState("");
+  const [startDate, setStartDate] = useState(fmtLocalDate(daysAgo(6)));
+  const [endDate, setEndDate] = useState(fmtLocalDate(new Date()));
+  const [ratingValue, setRatingValue] = useState<number | null>(null);
+  const [ratingComparator, setRatingComparator] = useState<ICullRatingComparator>("gt");
+  const [pickStatusFilter, setPickStatusFilter] = useState<Set<ICullPickStatus>>(new Set());
+  // Defaults to "unreviewed" (unlike the other filters) so the queue always
+  // opens on wherever you left off reviewing.
+  const [reviewStatusFilter, setReviewStatusFilter] = useState<Set<ICullReviewStatus>>(new Set(["unreviewed"]));
+  const [sortOrder, setSortOrder] = useState<"desc" | "asc">("desc");
+  const { exImmichUrl } = useConfig();
+  // Full-screen viewer's bottom control chips key off the site theme (the
+  // viewer's photo backdrop itself stays black in both themes — this only
+  // governs the translucent chip fill/text so it still contrasts with an
+  // arbitrary photo behind it).
+  const { resolvedTheme } = useTheme();
+  const isDarkViewerChrome = resolvedTheme !== "light";
+  const viewerChipBg = isDarkViewerChrome ? "bg-black/30" : "bg-white/30";
+  const viewerChipBorder = isDarkViewerChrome ? "border-white/20" : "border-black/15";
+  const viewerMutedText = isDarkViewerChrome ? "text-white/60" : "text-black/60";
+  const viewerMutedHint = isDarkViewerChrome ? "text-white/50" : "text-black/50";
+  const viewerHoverBg = isDarkViewerChrome ? "hover:bg-white/10" : "hover:bg-black/10";
+  const viewerStarMuted = isDarkViewerChrome ? "text-white/40" : "text-black/40";
+  const viewerOnBg = isDarkViewerChrome ? "bg-white/20 text-white" : "bg-black/20 text-black";
+
+  // --- data ---
+  const [assets, setAssets] = useState<ICullAsset[]>([]);
+  const [total, setTotal] = useState(0);
+  const [hasNext, setHasNext] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const pageRef = useRef(1);
+
+  // --- selection & viewer ---
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [lastSelectedIndex, setLastSelectedIndex] = useState(-1);
+  const [viewerIndex, setViewerIndex] = useState<number | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [showExif, setShowExif] = useState(false);
+  const [shortcuts, setShortcutsState] = useState(loadCullShortcuts);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const setShortcuts = useCallback((next: Record<ICullShortcutAction, string>) => {
+    setShortcutsState(next);
+    saveCullShortcuts(next);
+  }, []);
+
+  const tagIdsRef = useRef<{ pick?: string; reject?: string; reviewed?: string }>({});
+  const prefetchedRef = useRef<Map<string, HTMLImageElement>>(new Map());
+
+  // Resolve (create-or-get) all three flag tags once so keypresses never wait.
+  useEffect(() => {
+    ensureCullTags()
+      .then((ids) => { tagIdsRef.current = ids; })
+      .catch(() => toast({ title: "Error", description: "Couldn't set up Pick/Reject/Reviewed tags.", variant: "destructive" }));
+  }, []);
+
+  // Closing the viewer clears the EXIF panel so reopening it starts fresh.
+  useEffect(() => {
+    if (viewerIndex === null) setShowExif(false);
+  }, [viewerIndex]);
+
+  useEffect(() => {
+    listAlbums().then(setAlbums).catch(() => {
+      toast({ title: "Error", description: "Failed to load albums.", variant: "destructive" });
+    });
+  }, []);
+
+  const sourceParams = useMemo(() => {
+    if (mode === "album") return albumId ? { albumId } : null; // null = not ready to fetch
+    if (mode === "range") return startDate && endDate ? { startDate, endDate } : null;
+    return {};
+  }, [mode, albumId, startDate, endDate]);
+
+  const fetchPage = useCallback(
+    async (page: number, reset: boolean) => {
+      if (!sourceParams) return;
+      reset ? setLoading(true) : setLoadingMore(true);
+      try {
+        const res = await listCullAssets({
+          ...sourceParams,
+          ratingValue,
+          ratingComparator,
+          flag: Array.from(pickStatusFilter),
+          reviewed: Array.from(reviewStatusFilter),
+          sortOrder,
+          page,
+          limit: PAGE_SIZE,
+        });
+        pageRef.current = page;
+        setAssets((prev) => (reset ? res.assets : [...prev, ...res.assets]));
+        setTotal(res.total);
+        setHasNext(res.hasNext);
+      } catch (e: any) {
+        toast({ title: "Error", description: `Failed to load photos: ${e?.error || e?.message || "unknown"}`, variant: "destructive" });
+      } finally {
+        reset ? setLoading(false) : setLoadingMore(false);
+      }
+    },
+    [sourceParams, ratingValue, ratingComparator, pickStatusFilter, reviewStatusFilter, sortOrder]
+  );
+
+  // Any source/filter change restarts from page 1 (server does the filtering).
+  useEffect(() => {
+    setAssets([]);
+    setSelectedIds([]);
+    setViewerIndex(null);
+    setTotal(0);
+    setHasNext(false);
+    fetchPage(1, true);
+  }, [fetchPage]);
+
+  const loadMore = useCallback(() => {
+    if (loadingMore || loading || !hasNext) return;
+    fetchPage(pageRef.current + 1, false);
+  }, [fetchPage, hasNext, loading, loadingMore]);
+
+  // Keep culling past the loaded window: viewer nearing the end pulls the
+  // next page before the user hits the wall.
+  useEffect(() => {
+    if (viewerIndex !== null && viewerIndex >= assets.length - 25 && hasNext && !loadingMore) loadMore();
+  }, [viewerIndex, assets.length, hasNext, loadingMore, loadMore]);
+
+  // Prefetch neighbors of the current photo so arrows feel instant. Bounded
+  // map so a long session doesn't hold hundreds of decoded previews.
+  useEffect(() => {
+    if (viewerIndex === null) return;
+    for (const off of [1, 2, 3, 4, -1, -2]) {
+      const a = assets[viewerIndex + off];
+      if (!a || a.type === "VIDEO" || prefetchedRef.current.has(a.id)) continue;
+      const img = new window.Image();
+      img.src = ASSET_PREVIEW_PATH(a.id);
+      prefetchedRef.current.set(a.id, img);
+      if (prefetchedRef.current.size > 40) {
+        const oldest = prefetchedRef.current.keys().next().value;
+        if (oldest) prefetchedRef.current.delete(oldest);
+      }
+    }
+  }, [viewerIndex, assets]);
+
+  // --- mutations (all optimistic, with snapshot revert on failure) ---
+
+  const patchLocal = (ids: string[], patch: Partial<ICullAsset>) => {
+    const idSet = new Set(ids);
+    setAssets((prev) => prev.map((a) => (idSet.has(a.id) ? { ...a, ...patch } : a)));
+  };
+
+  const snapshot = (ids: string[]) => {
+    const idSet = new Set(ids);
+    return assets.filter((a) => idSet.has(a.id)).map((a) => ({ ...a }));
+  };
+
+  const restore = (snap: ICullAsset[]) => {
+    const byId = new Map(snap.map((a) => [a.id, a]));
+    setAssets((prev) => prev.map((a) => byId.get(a.id) ?? a));
+  };
+
+  const rateAssets = useCallback(async (ids: string[], rating: number | null) => {
+    const snap = snapshot(ids);
+    patchLocal(ids, { rating });
+    try {
+      await updateAssets({ ids, rating });
+    } catch {
+      restore(snap);
+      toast({ title: "Error", description: "Failed to set rating.", variant: "destructive" });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assets]);
+
+  const flagAssets = useCallback(async (ids: string[], flag: IFlag) => {
+    const { pick, reject } = tagIdsRef.current;
+    if (!pick || !reject) {
+      toast({ title: "Hang on", description: "Still preparing Pick/Reject tags…" });
+      return;
+    }
+    const snap = snapshot(ids);
+    patchLocal(ids, { picked: flag === "pick", rejected: flag === "reject" });
+    try {
+      // Unconditional add/remove pair — idempotent, race-free, and exactly
+      // what enforces "never both picked and rejected".
+      if (flag === "pick") {
+        await Promise.all([removeTagFromAssets(reject, ids), addTagToAssets(pick, ids)]);
+      } else if (flag === "reject") {
+        await Promise.all([removeTagFromAssets(pick, ids), addTagToAssets(reject, ids)]);
+      } else {
+        await Promise.all([removeTagFromAssets(pick, ids), removeTagFromAssets(reject, ids)]);
+      }
+    } catch {
+      restore(snap);
+      toast({ title: "Error", description: "Failed to update flag.", variant: "destructive" });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assets]);
+
+  const reviewAssets = useCallback(async (ids: string[], reviewed: boolean) => {
+    const { reviewed: reviewedTagId } = tagIdsRef.current;
+    if (!reviewedTagId) {
+      toast({ title: "Hang on", description: "Still preparing the Reviewed tag…" });
+      return;
+    }
+    const snap = snapshot(ids);
+    patchLocal(ids, { reviewed });
+    try {
+      if (reviewed) await addTagToAssets(reviewedTagId, ids);
+      else await removeTagFromAssets(reviewedTagId, ids);
+    } catch {
+      restore(snap);
+      toast({ title: "Error", description: "Failed to update reviewed status.", variant: "destructive" });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assets]);
+
+  const favoriteAssets = useCallback(async (ids: string[], isFavorite: boolean) => {
+    const snap = snapshot(ids);
+    patchLocal(ids, { isFavorite });
+    try {
+      await updateAssets({ ids, isFavorite });
+    } catch {
+      restore(snap);
+      toast({ title: "Error", description: "Failed to update favorite.", variant: "destructive" });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assets]);
+
+  /** Drop ids from the loaded list (after archive/trash), fixing selection + viewer. */
+  const removeFromList = (ids: string[]) => {
+    const idSet = new Set(ids);
+    setAssets((prev) => {
+      const next = prev.filter((a) => !idSet.has(a.id));
+      setViewerIndex((vi) => {
+        if (vi === null) return null;
+        if (!next.length) return null;
+        // Removing the current photo keeps the index: the next photo slides
+        // into place, which is the Lightroom cull rhythm.
+        const removedBefore = prev.slice(0, vi).filter((a) => idSet.has(a.id)).length;
+        return Math.min(vi - removedBefore, next.length - 1);
+      });
+      return next;
+    });
+    setSelectedIds((prev) => prev.filter((id) => !idSet.has(id)));
+    setTotal((t) => Math.max(0, t - ids.length));
+  };
+
+  const archiveAssets = useCallback(async (ids: string[]) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await updateAssets({ ids, visibility: "archive" });
+      removeFromList(ids);
+      toast({ title: `Archived ${ids.length} photo${ids.length === 1 ? "" : "s"}` });
+    } catch {
+      toast({ title: "Error", description: "Failed to archive.", variant: "destructive" });
+    } finally {
+      setBusy(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [busy]);
+
+  const trashAssets = useCallback(async (ids: string[]) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await deleteAssets(ids, { force: false }); // Immich trash, NOT permanent
+      removeFromList(ids);
+      toast({ title: `Moved ${ids.length} photo${ids.length === 1 ? "" : "s"} to Immich's trash` });
+    } catch {
+      toast({ title: "Error", description: "Failed to delete.", variant: "destructive" });
+    } finally {
+      setBusy(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [busy]);
+
+  // --- keyboard ---
+  const viewerAsset = viewerIndex !== null ? assets[viewerIndex] ?? null : null;
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target) || shortcutsOpen) return;
+
+      // Cmd/Ctrl+A selects every loaded photo (grid only — the viewer has
+      // nothing to multi-select). Checked before the modifier early-return.
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "a" && viewerIndex === null) {
+        e.preventDefault();
+        if (assets.length) setSelectedIds(assets.map((a) => a.id));
+        return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      // Keys act on the viewer photo when it's open, else on the grid selection.
+      const targetIds = viewerAsset ? [viewerAsset.id] : selectedIds;
+
+      if (e.key === "Escape") {
+        if (viewerIndex !== null) setViewerIndex(null);
+        else if (selectedIds.length) setSelectedIds([]);
+        return;
+      }
+      if (viewerIndex !== null) {
+        if (e.key === "ArrowRight") { e.preventDefault(); setViewerIndex((i) => Math.min((i ?? 0) + 1, assets.length - 1)); return; }
+        if (e.key === "ArrowLeft") { e.preventDefault(); setViewerIndex((i) => Math.max((i ?? 0) - 1, 0)); return; }
+        if (keyMatches(e, shortcuts.info)) { e.preventDefault(); setShowExif((v) => !v); return; }
+      }
+      if (!targetIds.length) return;
+
+      if (e.key === "0") {
+        // Lightroom convention: 0 clears the rating. (Immich's rating field
+        // has no 0 — only 1-5, -1, or null — so this maps straight to null.)
+        e.preventDefault();
+        rateAssets(targetIds, null);
+      } else if (e.key >= "1" && e.key <= "5") {
+        e.preventDefault();
+        const n = Number(e.key);
+        // Re-pressing the current rating clears it (single-photo only, where
+        // "current" is unambiguous).
+        const clear = viewerAsset && viewerAsset.rating === n;
+        rateAssets(targetIds, clear ? null : n);
+      } else if (keyMatches(e, shortcuts.pick)) {
+        e.preventDefault();
+        // Toggle is only unambiguous for the single open photo; a bulk grid
+        // selection just gets marked picked (same convention as Reviewed/
+        // Favorite below) — Unflag is still there for bulk clearing.
+        flagAssets(targetIds, viewerAsset && viewerAsset.picked ? null : "pick");
+      } else if (keyMatches(e, shortcuts.reject)) {
+        e.preventDefault();
+        flagAssets(targetIds, viewerAsset && viewerAsset.rejected ? null : "reject");
+      } else if (keyMatches(e, shortcuts.unflag)) {
+        e.preventDefault();
+        flagAssets(targetIds, null);
+      } else if (keyMatches(e, shortcuts.reviewed)) {
+        e.preventDefault();
+        reviewAssets(targetIds, !(viewerAsset && viewerAsset.reviewed));
+      } else if (keyMatches(e, shortcuts.favorite)) {
+        e.preventDefault();
+        favoriteAssets(targetIds, !(viewerAsset && viewerAsset.isFavorite));
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [viewerAsset, viewerIndex, selectedIds, assets.length, shortcuts, shortcutsOpen, rateAssets, flagAssets, reviewAssets, favoriteAssets]);
+
+  // --- grid photos ---
+  const images: AssetPhoto[] = useMemo(() => {
+    const selectedSet = new Set(selectedIds);
+    return assets.map((a) => ({
+      id: a.id,
+      src: ASSET_THUMBNAIL_PATH(a.id),
+      width: a.exifImageWidth || 1500,
+      height: a.exifImageHeight || 1000,
+      isSelected: selectedSet.has(a.id),
+      isVideo: a.type === "VIDEO",
+      duration: a.duration != null ? String(a.duration) : undefined,
+    }));
+  }, [assets, selectedIds]);
+
+  // O(1) lookup for the grid's per-thumbnail badge overlay — `assets.find`
+  // inside the extras renderer was O(n) per photo, O(n²) per grid render.
+  const assetsById = useMemo(() => new Map(assets.map((a) => [a.id, a])), [assets]);
+
+  // The one rating every selected photo shares (null when mixed or unrated) —
+  // lets the bulk bar's stars show the current state, so clicking the lit
+  // star clears it (replacing the old dedicated clear-rating button).
+  const sharedSelectedRating = useMemo(() => {
+    if (!selectedIds.length) return null;
+    let shared: number | null | undefined;
+    for (const id of selectedIds) {
+      const rating = assetsById.get(id)?.rating ?? null;
+      if (shared === undefined) shared = rating;
+      else if (rating !== shared) return null;
+    }
+    return shared ?? null;
+  }, [selectedIds, assetsById]);
+
+  const handleSelect = (photo: AssetPhoto, event: React.MouseEvent) => {
+    const clickedIndex = images.findIndex((i) => i.id === photo.id);
+    if (event.shiftKey && lastSelectedIndex >= 0) {
+      const [lo, hi] = [Math.min(clickedIndex, lastSelectedIndex), Math.max(clickedIndex, lastSelectedIndex)];
+      const range = images.slice(lo, hi + 1).map((i) => i.id);
+      setSelectedIds((prev) => [...new Set([...prev, ...range])]);
+    } else {
+      setSelectedIds((prev) =>
+        prev.includes(photo.id) ? prev.filter((id) => id !== photo.id) : [...prev, photo.id]
+      );
+    }
+    setLastSelectedIndex(clickedIndex);
+  };
+
+  const renderImage = (props: RenderImageProps, context: RenderImageContext<AssetPhoto>) => (
+    <LazyGridImage
+      imageProps={props}
+      photo={context.photo}
+      width={context.width}
+      height={context.height}
+      selectable
+      onSelect={(event) => handleSelect(context.photo, event)}
+      selectionMode={selectedIds.length > 0}
+    />
+  );
+
+  const selectionActive = selectedIds.length > 0;
+
+  // --- shared overlay pieces ---
+  const StarRow = ({
+    value, size, onRate, mutedClassName = "text-white/40",
+  }: { value: number | null; size: number; onRate: (n: number | null) => void; mutedClassName?: string }) => (
+    <span className="flex items-center">
+      {[1, 2, 3, 4, 5].map((n) => (
+        <button
+          key={n}
+          title={`${n} star${n === 1 ? "" : "s"} (key ${n})`}
+          className="p-1 hover:scale-125 transition-transform"
+          onClick={(e) => { e.stopPropagation(); onRate(value === n ? null : n); }}
+        >
+          <Star size={size} className={value !== null && n <= value ? "fill-amber-400 text-amber-400" : mutedClassName} />
+        </button>
+      ))}
+    </span>
+  );
+
+  // --- top filter bar: pick/review status are multi-select toggle sets;
+  // rating is a single star count plus a comparator that decides how it's
+  // applied (0 stars + "=" reads as Unrated, since there's no "0" star to click).
+  const togglePickStatus = (v: ICullPickStatus) =>
+    setPickStatusFilter((prev) => {
+      const next = new Set(prev);
+      next.has(v) ? next.delete(v) : next.add(v);
+      return next;
+    });
+
+  const toggleReviewStatus = (v: ICullReviewStatus) =>
+    setReviewStatusFilter((prev) => {
+      const next = new Set(prev);
+      next.has(v) ? next.delete(v) : next.add(v);
+      return next;
+    });
+
+  const cycleRatingComparator = () =>
+    setRatingComparator((prev) => (prev === "gt" ? "eq" : prev === "eq" ? "lt" : "gt"));
+
+  return (
+    <PageLayout title="Rate & Cull">
+      <Header
+        leftComponent="Rate & Cull"
+        rightComponent={
+          <div className="flex items-center gap-2">
+            <ShortcutSettings
+              open={shortcutsOpen}
+              onOpenChange={setShortcutsOpen}
+              shortcuts={shortcuts}
+              onChange={setShortcuts}
+            />
+            <HelpGuide shortcuts={shortcuts} />
+          </div>
+        }
+      />
+      <div className="flex flex-col gap-3 p-4">
+        {/* source + filter row */}
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="text-sm text-muted-foreground">Review</label>
+          <Select value={mode} onValueChange={(v) => setMode(v as ISourceMode)}>
+            <SelectTrigger className="w-40 h-8"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="library">Whole library</SelectItem>
+              <SelectItem value="album">Album</SelectItem>
+              <SelectItem value="range">Date range</SelectItem>
+            </SelectContent>
+          </Select>
+          {mode === "album" && (
+            <Select value={albumId} onValueChange={setAlbumId}>
+              <SelectTrigger className="w-72 h-8"><SelectValue placeholder="Choose an album…" /></SelectTrigger>
+              <SelectContent>
+                {albums.map((a) => (
+                  <SelectItem key={a.id} value={a.id}>{a.albumName} ({a.assetCount})</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {mode === "range" && (
+            <>
+              <Input type="date" className="h-8 w-40" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
+              <span className="text-sm text-muted-foreground">to</span>
+              <Input type="date" className="h-8 w-40" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
+              {DATE_PRESETS.map((p) => (
+                <Button
+                  key={p.label} size="sm" variant="ghost" className="h-8 px-2 text-xs"
+                  onClick={() => { const [s, en] = p.range(); setStartDate(s); setEndDate(en); }}
+                >
+                  {p.label}
+                </Button>
+              ))}
+            </>
+          )}
+          <Button
+            size="sm" variant="outline" className="h-8"
+            title="Select every loaded photo (Cmd/Ctrl+A)"
+            disabled={!assets.length || selectedIds.length === assets.length}
+            onClick={() => setSelectedIds(assets.map((a) => a.id))}
+          >
+            Select all
+          </Button>
+          <Button
+            size="sm" variant="outline" className="h-8"
+            title="Deselect all (Esc)"
+            disabled={!selectedIds.length}
+            onClick={() => setSelectedIds([])}
+          >
+            Deselect all
+          </Button>
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            <span className="flex items-center gap-1 text-sm text-muted-foreground">
+              <Filter size={14} /> Filters
+            </span>
+            {/* Pick status — multi-select */}
+            <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+              <button
+                type="button"
+                title="Picked"
+                className={`rounded p-1.5 ${pickStatusFilter.has("picked") ? "bg-emerald-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
+                onClick={() => togglePickStatus("picked")}
+              >
+                <CheckCircle2 size={15} />
+              </button>
+              <button
+                type="button"
+                title="Rejected"
+                className={`rounded p-1.5 ${pickStatusFilter.has("rejected") ? "bg-red-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
+                onClick={() => togglePickStatus("rejected")}
+              >
+                <XCircle size={15} />
+              </button>
+              <button
+                type="button"
+                title="Unflagged"
+                className={`rounded p-1.5 ${pickStatusFilter.has("unflagged") ? "bg-slate-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
+                onClick={() => togglePickStatus("unflagged")}
+              >
+                <Circle size={15} />
+              </button>
+            </div>
+
+            {/* Star rating — comparator cycles </>/=; 0 stars + "=" means Unrated */}
+            <div className="flex items-center gap-1 rounded-md border p-0.5 pl-2">
+              <button
+                type="button"
+                title={`Rating is ${ratingComparator === "eq" ? "exactly" : ratingComparator === "gt" ? "more than" : "less than"} the stars below (click to cycle)`}
+                className="w-4 text-sm font-semibold text-muted-foreground hover:text-foreground"
+                onClick={cycleRatingComparator}
+              >
+                {ratingComparator === "eq" ? "=" : ratingComparator === "gt" ? ">" : "<"}
+              </button>
+              <StarRow value={ratingValue} size={16} onRate={setRatingValue} mutedClassName="text-muted-foreground/40" />
+            </div>
+
+            {/* Review status — multi-select */}
+            <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+              <button
+                type="button"
+                title="Reviewed"
+                className={`rounded p-1.5 ${reviewStatusFilter.has("reviewed") ? "bg-sky-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
+                onClick={() => toggleReviewStatus("reviewed")}
+              >
+                <Glasses size={15} />
+              </button>
+              <button
+                type="button"
+                title="Unreviewed"
+                className={`rounded p-1.5 ${reviewStatusFilter.has("unreviewed") ? "bg-slate-600 text-white" : "text-muted-foreground hover:bg-accent"}`}
+                onClick={() => toggleReviewStatus("unreviewed")}
+              >
+                <GlassesOff size={15} />
+              </button>
+            </div>
+
+            {/* Sort direction */}
+            <Button
+              variant="default"
+              size="sm"
+              title={sortOrder === "asc" ? "Oldest first" : "Newest first"}
+              onClick={() => setSortOrder(sortOrder === "asc" ? "desc" : "asc")}
+            >
+              {sortOrder === "asc" ? <SortAsc size={16} /> : <SortDesc size={16} />}
+            </Button>
+          </div>
+        </div>
+
+        {/* grid */}
+        {loading ? (
+          <div className="flex justify-center py-24"><Loader2 className="animate-spin" /></div>
+        ) : !sourceParams ? (
+          <div className="py-24 text-center text-muted-foreground">
+            {mode === "album" ? "Choose an album above to start culling." : "Pick a date range above."}
+          </div>
+        ) : !assets.length ? (
+          <div className="py-24 text-center text-muted-foreground">No photos match this view.</div>
+        ) : (
+          <>
+            <RowsPhotoAlbum
+              photos={images}
+              targetRowHeight={150}
+              rowConstraints={{ singleRowMaxHeight: 300 }}
+              spacing={2}
+              padding={0}
+              onClick={({ index, event, photo }) => {
+                if (event.metaKey || event.ctrlKey || event.shiftKey || selectionActive) handleSelect(photo, event);
+                else setViewerIndex(index);
+              }}
+              render={{
+                image: renderImage,
+                extras: (_, { photo }) => {
+                  const a = assetsById.get(photo.id);
+                  if (!a || (!a.rating && !a.picked && !a.rejected && !a.reviewed && !a.isFavorite)) return null;
+                  return (
+                    <div className="pointer-events-none absolute bottom-1 left-1 flex items-center gap-1">
+                      {!!a.rating && (
+                        <span className="rounded bg-black/60 px-1 py-0.5 text-[10px] font-semibold text-amber-400">
+                          ★{a.rating}
+                        </span>
+                      )}
+                      {a.picked && (
+                        <span className="rounded bg-emerald-600/90 px-1 py-0.5 text-[10px] font-semibold text-white">P</span>
+                      )}
+                      {a.rejected && (
+                        <span className="rounded bg-red-600/90 px-1 py-0.5 text-[10px] font-semibold text-white">✕</span>
+                      )}
+                      {a.reviewed && (
+                        <span className="rounded bg-sky-600/90 px-1 py-0.5 text-[10px] font-semibold text-white">✓</span>
+                      )}
+                      {a.isFavorite && (
+                        <span className="rounded bg-black/60 p-0.5">
+                          <Heart size={10} className="fill-pink-500 text-pink-500" />
+                        </span>
+                      )}
+                    </div>
+                  );
+                },
+              }}
+            />
+            <div className="flex justify-center py-2">
+              {loadingMore ? (
+                <Loader2 className="animate-spin text-muted-foreground" />
+              ) : hasNext ? (
+                <Button variant="ghost" onClick={loadMore}>Load more ({(total - assets.length).toLocaleString()} left)</Button>
+              ) : null}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* bulk action bar */}
+      {selectionActive && viewerIndex === null && (
+        <FloatingBar className="!max-w-[95vw] w-fit flex-wrap justify-center gap-2">
+          <div className="flex flex-col px-2 whitespace-nowrap">
+            <span className="text-sm font-semibold">{selectedIds.length} selected</span>
+            <span className="text-[10px] leading-tight text-muted-foreground">Rating controls</span>
+          </div>
+          {/* Rating — shows the selection's shared rating; clicking the lit
+              star clears it (no separate clear-rating button). */}
+          <div className="flex items-center rounded-md border p-0.5">
+            <span className="pl-1.5 text-[10px] font-medium text-muted-foreground select-none">1–5</span>
+            <StarRow
+              value={sharedSelectedRating}
+              size={16}
+              onRate={(n) => rateAssets(selectedIds, n)}
+              mutedClassName="text-muted-foreground/40"
+            />
+          </div>
+          {/* Pick status */}
+          <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+            <span className="px-1 text-[10px] font-medium text-muted-foreground select-none">
+              {displayKey(shortcuts.pick)}/{displayKey(shortcuts.reject)}/{displayKey(shortcuts.unflag)}
+            </span>
+            <Button size="sm" variant="ghost" className="h-7 px-2" title={`Pick (${displayKey(shortcuts.pick)})`} onClick={() => flagAssets(selectedIds, "pick")}>
+              <CheckCircle2 size={15} className="text-emerald-500" />
+            </Button>
+            <Button size="sm" variant="ghost" className="h-7 px-2" title={`Reject (${displayKey(shortcuts.reject)})`} onClick={() => flagAssets(selectedIds, "reject")}>
+              <XCircle size={15} className="text-red-500" />
+            </Button>
+            <Button size="sm" variant="ghost" className="h-7 px-2" title={`Unflag (${displayKey(shortcuts.unflag)})`} onClick={() => flagAssets(selectedIds, null)}>
+              <Circle size={15} className="text-muted-foreground" />
+            </Button>
+          </div>
+          {/* Review status */}
+          <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+            <span className="px-1 text-[10px] font-medium text-muted-foreground select-none">{displayKey(shortcuts.reviewed)}</span>
+            <Button size="sm" variant="ghost" className="h-7 px-2" title={`Mark Reviewed (${displayKey(shortcuts.reviewed)})`} onClick={() => reviewAssets(selectedIds, true)}>
+              <Glasses size={15} className="text-sky-500" />
+            </Button>
+            <Button size="sm" variant="ghost" className="h-7 px-2" title="Mark Unreviewed" onClick={() => reviewAssets(selectedIds, false)}>
+              <GlassesOff size={15} className="text-muted-foreground" />
+            </Button>
+          </div>
+          {/* Favorite */}
+          <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+            <span className="px-1 text-[10px] font-medium text-muted-foreground select-none">{displayKey(shortcuts.favorite)}</span>
+            <Button size="sm" variant="ghost" className="h-7 px-2" title={`Favorite (${displayKey(shortcuts.favorite)})`} onClick={() => favoriteAssets(selectedIds, true)}>
+              <Heart size={15} className="fill-pink-500 text-pink-500" />
+            </Button>
+            <Button size="sm" variant="ghost" className="h-7 px-2" title="Unfavorite" onClick={() => favoriteAssets(selectedIds, false)}>
+              <Heart size={15} className="text-muted-foreground" />
+            </Button>
+          </div>
+          {/* Archive / trash */}
+          <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+            <Button size="sm" variant="ghost" className="h-7 px-2" title="Archive (hide from timeline, reversible)" disabled={busy} onClick={() => archiveAssets(selectedIds)}>
+              <Archive size={15} />
+            </Button>
+            <AlertDialog
+              asChild
+              disabled={busy}
+              title={`Move ${selectedIds.length} photo${selectedIds.length === 1 ? "" : "s"} to trash?`}
+              description="They go to Immich's trash (recoverable there until it's emptied), not permanent deletion."
+              onConfirm={() => trashAssets(selectedIds)}
+            >
+              <Button size="sm" variant="ghost" className="h-7 px-2" title="Move to trash" disabled={busy}>
+                <Trash2 size={15} className="text-red-500" />
+              </Button>
+            </AlertDialog>
+          </div>
+          <Button size="sm" variant="ghost" title="Clear selection (Esc)" onClick={() => setSelectedIds([])}>
+            <X size={15} />
+          </Button>
+        </FloatingBar>
+      )}
+
+      {/* full-screen viewer */}
+      {viewerAsset && (
+        <div className="fixed inset-0 z-[100] flex flex-col bg-black">
+          {/* top bar */}
+          <div className="absolute inset-x-0 top-0 z-10 flex items-center gap-3 bg-gradient-to-b from-black/70 to-transparent px-4 py-2 text-white">
+            <span className="text-sm tabular-nums">{(viewerIndex ?? 0) + 1} / {total.toLocaleString()}</span>
+            <span className="truncate text-sm text-white/70">{viewerAsset.originalFileName}</span>
+            <span className="text-xs text-white/50">
+              {viewerAsset.localDateTime ? String(viewerAsset.localDateTime).slice(0, 10) : ""}
+            </span>
+            <div className="ml-auto flex items-center gap-1">
+              <a
+                href={`${exImmichUrl}/photos/${viewerAsset.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded p-1 hover:bg-white/10"
+                title="Open in Immich"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <ExternalLink size={18} />
+              </a>
+              <button
+                className={`rounded p-1 hover:bg-white/10 ${showExif ? "bg-white/10" : ""}`}
+                title={`Info (${displayKey(shortcuts.info)})`}
+                onClick={(e) => { e.stopPropagation(); setShowExif((v) => !v); }}
+              >
+                <Info size={18} />
+              </button>
+              <button className="rounded p-1 hover:bg-white/10" title="Close (Esc)" onClick={() => setViewerIndex(null)}>
+                <X size={20} />
+              </button>
+            </div>
+          </div>
+          {showExif && <ExifPanel assetId={viewerAsset.id} />}
+
+          {/* image — as much screen as possible */}
+          <div className="flex min-h-0 flex-1 items-center justify-center" onClick={() => setViewerIndex(null)}>
+            {viewerAsset.type === "VIDEO" ? (
+              <video
+                key={viewerAsset.id}
+                src={ASSET_VIDEO_PATH(viewerAsset.id)}
+                controls
+                className="max-h-full max-w-full"
+                onClick={(e) => e.stopPropagation()}
+              />
+            ) : (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                key={viewerAsset.id}
+                src={ASSET_PREVIEW_PATH(viewerAsset.id)}
+                alt={viewerAsset.originalFileName}
+                className="h-full w-full object-contain"
+                onClick={(e) => e.stopPropagation()}
+              />
+            )}
+          </div>
+
+          {/* nav chevrons */}
+          <button
+            className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-2 text-white hover:bg-black/70 disabled:opacity-20"
+            disabled={viewerIndex === 0}
+            title="Previous (←)"
+            onClick={() => setViewerIndex((i) => Math.max((i ?? 0) - 1, 0))}
+          >
+            <ChevronLeft size={24} />
+          </button>
+          <button
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-2 text-white hover:bg-black/70 disabled:opacity-20"
+            disabled={viewerIndex === assets.length - 1 && !hasNext}
+            title="Next (→)"
+            onClick={() => setViewerIndex((i) => Math.min((i ?? 0) + 1, assets.length - 1))}
+          >
+            <ChevronRight size={24} />
+          </button>
+
+          {/* bottom overlay: same bordered-cluster + key-hint layout as the
+              grid's bulk-action bar, just targeting this one photo. Each
+              group carries its own solid 30%-opacity chip (instead of one
+              whole-strip gradient) so it contrasts with the photo directly
+              behind it regardless of that photo's own colors; the chip tint
+              itself follows the site theme. flex-wrap so nothing clips
+              off-screen on phones. */}
+          <div className="absolute inset-x-0 bottom-0 z-10 flex flex-wrap items-center justify-center gap-2 px-4 py-3">
+            {/* Rating */}
+            <div className={`flex items-center rounded-md border ${viewerChipBorder} ${viewerChipBg} p-0.5`}>
+              <span className={`pl-1.5 text-[10px] font-medium ${viewerMutedHint} select-none`}>1–5</span>
+              <StarRow value={viewerAsset.rating} size={22} onRate={(n) => rateAssets([viewerAsset.id], n)} mutedClassName={viewerStarMuted} />
+            </div>
+            {/* Pick status */}
+            <div className={`flex items-center gap-0.5 rounded-md border ${viewerChipBorder} ${viewerChipBg} p-0.5`}>
+              <span className={`px-1 text-[10px] font-medium ${viewerMutedHint} select-none`}>
+                {displayKey(shortcuts.pick)}/{displayKey(shortcuts.reject)}/{displayKey(shortcuts.unflag)}
+              </span>
+              <button
+                title={`Pick (${displayKey(shortcuts.pick)})`}
+                className={`rounded p-1.5 ${viewerAsset.picked ? "bg-emerald-600 text-white" : `${viewerMutedText} ${viewerHoverBg}`}`}
+                onClick={() => flagAssets([viewerAsset.id], "pick")}
+              >
+                <CheckCircle2 size={15} />
+              </button>
+              <button
+                title={`Reject (${displayKey(shortcuts.reject)})`}
+                className={`rounded p-1.5 ${viewerAsset.rejected ? "bg-red-600 text-white" : `${viewerMutedText} ${viewerHoverBg}`}`}
+                onClick={() => flagAssets([viewerAsset.id], "reject")}
+              >
+                <XCircle size={15} />
+              </button>
+              <button
+                title={`Unflag (${displayKey(shortcuts.unflag)})`}
+                className={`rounded p-1.5 ${!viewerAsset.picked && !viewerAsset.rejected ? viewerOnBg : `${viewerMutedText} ${viewerHoverBg}`}`}
+                onClick={() => flagAssets([viewerAsset.id], null)}
+              >
+                <Circle size={15} />
+              </button>
+            </div>
+            {/* Review status */}
+            <div className={`flex items-center gap-0.5 rounded-md border ${viewerChipBorder} ${viewerChipBg} p-0.5`}>
+              <span className={`px-1 text-[10px] font-medium ${viewerMutedHint} select-none`}>{displayKey(shortcuts.reviewed)}</span>
+              <button
+                title={`Mark Reviewed (${displayKey(shortcuts.reviewed)})`}
+                className={`rounded p-1.5 ${viewerAsset.reviewed ? "bg-sky-600 text-white" : `${viewerMutedText} ${viewerHoverBg}`}`}
+                onClick={() => reviewAssets([viewerAsset.id], true)}
+              >
+                <Glasses size={15} />
+              </button>
+              <button
+                title="Mark Unreviewed"
+                className={`rounded p-1.5 ${!viewerAsset.reviewed ? viewerOnBg : `${viewerMutedText} ${viewerHoverBg}`}`}
+                onClick={() => reviewAssets([viewerAsset.id], false)}
+              >
+                <GlassesOff size={15} />
+              </button>
+            </div>
+            {/* Favorite */}
+            <div className={`flex items-center gap-0.5 rounded-md border ${viewerChipBorder} ${viewerChipBg} p-0.5`}>
+              <span className={`px-1 text-[10px] font-medium ${viewerMutedHint} select-none`}>{displayKey(shortcuts.favorite)}</span>
+              <button
+                title={`Favorite (${displayKey(shortcuts.favorite)})`}
+                className={`rounded p-1.5 ${viewerAsset.isFavorite ? "text-pink-500" : `${viewerMutedText} ${viewerHoverBg}`}`}
+                onClick={() => favoriteAssets([viewerAsset.id], true)}
+              >
+                <Heart size={15} className={viewerAsset.isFavorite ? "fill-pink-500" : ""} />
+              </button>
+              <button
+                title="Unfavorite"
+                className={`rounded p-1.5 ${!viewerAsset.isFavorite ? viewerOnBg : `${viewerMutedText} ${viewerHoverBg}`}`}
+                onClick={() => favoriteAssets([viewerAsset.id], false)}
+              >
+                <Heart size={15} />
+              </button>
+            </div>
+            {/* Archive / trash */}
+            <div className={`flex items-center gap-0.5 rounded-md border ${viewerChipBorder} ${viewerChipBg} p-0.5`}>
+              <button
+                title="Archive (hide from timeline, reversible)"
+                className={`rounded p-1.5 ${viewerMutedText} ${viewerHoverBg} disabled:opacity-40`}
+                disabled={busy}
+                onClick={() => archiveAssets([viewerAsset.id])}
+              >
+                <Archive size={15} />
+              </button>
+              <AlertDialog
+                asChild
+                disabled={busy}
+                title="Move this photo to trash?"
+                description="It goes to Immich's trash (recoverable there until it's emptied), not permanent deletion."
+                onConfirm={() => trashAssets([viewerAsset.id])}
+              >
+                <button className={`rounded p-1.5 text-red-400 ${viewerHoverBg} disabled:opacity-40`} disabled={busy}>
+                  <Trash2 size={15} />
+                </button>
+              </AlertDialog>
+            </div>
+          </div>
+        </div>
+      )}
+    </PageLayout>
+  );
+}

--- a/src/pages/assets/cull.tsx
+++ b/src/pages/assets/cull.tsx
@@ -381,6 +381,12 @@ export default function CullPhotosPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [busy]);
 
+  // O(1) lookup for the grid's per-thumbnail badge overlay — `assets.find`
+  // inside the extras renderer was O(n) per photo, O(n²) per grid render.
+  // Declared above the keyboard effect so the bulk shortcuts can read the
+  // selection's current state.
+  const assetsById = useMemo(() => new Map(assets.map((a) => [a.id, a])), [assets]);
+
   // --- keyboard ---
   const viewerAsset = viewerIndex !== null ? assets[viewerIndex] ?? null : null;
 
@@ -427,8 +433,9 @@ export default function CullPhotosPage() {
       } else if (keyMatches(e, shortcuts.pick)) {
         e.preventDefault();
         // Toggle is only unambiguous for the single open photo; a bulk grid
-        // selection just gets marked picked (same convention as Reviewed/
-        // Favorite below) — Unflag is still there for bulk clearing.
+        // selection just gets marked picked — Unflag (U) is the bulk clear,
+        // which is why Pick/Reject don't toggle off the way Reviewed and
+        // Favorite (which have no "un-" key) do.
         flagAssets(targetIds, viewerAsset && viewerAsset.picked ? null : "pick");
       } else if (keyMatches(e, shortcuts.reject)) {
         e.preventDefault();
@@ -438,15 +445,25 @@ export default function CullPhotosPage() {
         flagAssets(targetIds, null);
       } else if (keyMatches(e, shortcuts.reviewed)) {
         e.preventDefault();
-        reviewAssets(targetIds, !(viewerAsset && viewerAsset.reviewed));
+        // Toggle: in the viewer, flip the open photo; for a grid selection,
+        // un-review only if every selected photo is already reviewed, else
+        // mark them all reviewed. (Unlike Pick/Reject, Reviewed has no
+        // separate "un-" key, so the shortcut must toggle both ways.)
+        const nextReviewed = viewerAsset
+          ? !viewerAsset.reviewed
+          : !selectedIds.every((id) => assetsById.get(id)?.reviewed);
+        reviewAssets(targetIds, nextReviewed);
       } else if (keyMatches(e, shortcuts.favorite)) {
         e.preventDefault();
-        favoriteAssets(targetIds, !(viewerAsset && viewerAsset.isFavorite));
+        const nextFavorite = viewerAsset
+          ? !viewerAsset.isFavorite
+          : !selectedIds.every((id) => assetsById.get(id)?.isFavorite);
+        favoriteAssets(targetIds, nextFavorite);
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [viewerAsset, viewerIndex, selectedIds, assets.length, shortcuts, shortcutsOpen, rateAssets, flagAssets, reviewAssets, favoriteAssets]);
+  }, [viewerAsset, viewerIndex, selectedIds, assets.length, assetsById, shortcuts, shortcutsOpen, rateAssets, flagAssets, reviewAssets, favoriteAssets]);
 
   // --- grid photos ---
   const images: AssetPhoto[] = useMemo(() => {
@@ -461,10 +478,6 @@ export default function CullPhotosPage() {
       duration: a.duration != null ? String(a.duration) : undefined,
     }));
   }, [assets, selectedIds]);
-
-  // O(1) lookup for the grid's per-thumbnail badge overlay — `assets.find`
-  // inside the extras renderer was O(n) per photo, O(n²) per grid render.
-  const assetsById = useMemo(() => new Map(assets.map((a) => [a.id, a])), [assets]);
 
   // The one rating every selected photo shares (null when mixed or unrated) —
   // lets the bulk bar's stars show the current state, so clicking the lit


### PR DESCRIPTION
## What this adds

A Lightroom-style rating and culling workflow at **`/assets/cull`** (sidebar:
Tools → Rate & Cull). It's built for going through a shoot quickly from the
keyboard: rate, mark keepers/rejects, and archive or trash — all without
leaving the grid or the full-screen viewer.

### How it stores things (all in Immich, nothing app-local)

- **Star rating** uses Immich's native `asset_exif.rating` (1–5), and
  **Favorite** uses native `isFavorite`. Both are written through the bulk
  `PUT /assets` endpoint using the requesting user's own session — Power
  Tools never escalates.
- **Pick / Reject / Reviewed** are Immich **tags**, nested under a namespace
  (`ImmichPowerTools_CullandRate/IPT_{Picked,Rejected,Reviewed}`) so they
  can't collide with a user's own tags. They're deliberately kept separate
  from the star rating, so a photo can be e.g. "4 stars **and** rejected".
  Tags are created-or-fetched, then assigned via the proxied Immich tag
  endpoints.

### Server side

- `/api/assets/cull-assets` paginates and filters server-side (drizzle),
  with the review filter **defaulting to Unreviewed** so the queue opens
  where you left off. Filters: rating (with a `<`/`>`/`=` comparator),
  pick status, review status, and **asset type** (All / Photos / Videos —
  allowlisted to IMAGE/VIDEO so an unrecognized value is rejected rather than
  silently returning an empty feed).

### UX

- The **filter bar is sticky** — it stays pinned to the top while the grid
  scrolls, with an opaque backdrop-blurred background so thumbnails don't show
  through behind it.
- A **Photos / Videos** filter (three icons: All / Photos only / Videos only)
  sits in the filter cluster.
- Fully keyboard-driven (rate 1–5/0, pick/reject/unflag, reviewed, favorite,
  EXIF panel, arrow navigation) with on-screen equivalents for every key.
  The six quick-action keys are user-remappable (stored client-side).
- Delete → Immich **trash** (`force:false`); Archive → `visibility:archive`.
  Both reversible.

## Scope / shared-file changes

New code is self-contained under `src/components/cull/`, `src/lib/cull/`,
`src/config/constants/cull.ts`, `src/handlers/api/cull.handler.ts`,
`src/pages/api/assets/cull-assets.ts`, and `src/pages/assets/cull.tsx`.

Shared changes are intentionally small:
- one sidebar entry (`sidebarNavs.tsx`),
- a few route constants (`routes.ts`) — including create-or-get-tag /
  assign-tag paths, since the flags are Immich tags,
- two optional fields (`rating`, `visibility`) added to `IUpdateAssetsParams`.

## Testing

- `tsc --noEmit` clean.
- Exercised on a live ~26k-asset Immich v3 instance: rating/favorite/pick/
  reject/reviewed round-trips, filters, trash and archive (both reversed),
  and keyboard shortcuts including remap.

