### PR TITLE
feat: Tag Manager — tag-tree editor with counts, search, and nesting

### DIFF
--- a/src/components/tag-manager/HelpGuide.tsx
+++ b/src/components/tag-manager/HelpGuide.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { HelpCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger,
+} from "@/components/ui/dialog";
+
+/**
+ * User guide for Tag Manager — the "?" button in the page header. Written
+ * out as a component (not inline JSX in the page) so the actual guide
+ * content is easy to find and update on its own.
+ */
+export default function HelpGuide() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          size="sm" variant="ghost"
+          className="h-7 w-7 rounded-full border border-blue-500 p-0 text-blue-500 hover:bg-blue-500/10 hover:text-blue-500"
+          title="How Tag Manager works"
+        >
+          <HelpCircle size={16} />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>How Tag Manager works</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4 text-sm leading-relaxed">
+          <section>
+            <h3 className="font-semibold">The basics</h3>
+            <p className="mt-1 text-muted-foreground">
+              Tags nest (e.g. <code className="rounded bg-muted px-1">Vacation/Europe2024</code>).
+              Click a name to rename it, the colored tag icon to change its color, the folder icon
+              to move it under a different parent (or to top level), and the trash icon to delete
+              it. The + button adds a sub-tag. The count next to each tag is how many photos carry
+              that exact tag — sub-tag photos aren&apos;t added in, and photos in Immich&apos;s
+              trash don&apos;t count. Only your own tags show here — this is a shared library, and
+              other people&apos;s tags stay theirs.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="font-semibold">Rename, nest, and un-nest actually recreate the tag</h3>
+            <p className="mt-1 text-muted-foreground">
+              Immich&apos;s own API can&apos;t rename a tag or move it to a different parent —
+              verified directly against the server; its update endpoint only supports changing the
+              color. So Tag Manager does it the safe way behind the scenes: it creates the tag (and
+              any sub-tags, if you&apos;re moving a whole branch) at the new name or spot, copies
+              over which photos were tagged, then deletes the old one. Everything you see comes out
+              correct, but <strong>the tag gets a new internal ID</strong> every time you rename or
+              move it. Deleting it directly, plain create, and color changes don&apos;t have this
+              side effect — only rename/nest/un-nest do.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="font-semibold">This can silently break Workflow conditions</h3>
+            <p className="mt-1 text-muted-foreground">
+              If a Workflow&apos;s condition matches on a specific tag, it&apos;s stored by that
+              tag&apos;s ID, not its name. Renaming, nesting, un-nesting, or deleting a tag that a
+              workflow depends on won&apos;t error — the workflow just quietly stops matching
+              anything, since the ID it&apos;s looking for no longer exists. If you edit a tag that
+              a workflow uses, open that workflow afterward and re-select the tag in its condition.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="font-semibold">Deleting a tag with sub-tags</h3>
+            <p className="mt-1 text-muted-foreground">
+              Immich&apos;s database cascades tag deletion to the whole branch underneath it — the
+              confirm dialog tells you how many sub-tags and photos are affected before you commit.
+              Deleting a tag never touches the photos themselves, only the tag (and, for a branch,
+              its sub-tags).
+            </p>
+          </section>
+
+          <section>
+            <h3 className="font-semibold">Viewing tagged photos</h3>
+            <p className="mt-1 text-muted-foreground">
+              The external-link icon on each row opens Immich&apos;s own Tags browser filtered to
+              that exact tag, in a new tab.
+            </p>
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/tag-manager/MovePopover.tsx
+++ b/src/components/tag-manager/MovePopover.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Check } from "lucide-react";
+
+import {
+  Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList,
+} from "@/components/ui/command";
+import { ITag } from "@/handlers/api/tag.handler";
+import { getSubtreeIds } from "@/lib/tag-manager/tree";
+
+/**
+ * "Move to…" search list, rendered inline below a TagRow (same slot as the
+ * "add sub-tag" input) rather than in a floating Popover — a Popover here
+ * would nest one Radix portal inside another (the row's "⋮" DropdownMenu),
+ * which closes the outer menu before the inner one can open. Excludes the
+ * tag itself and its own descendants (would cycle).
+ */
+export default function MovePopover({
+  tag,
+  allTags,
+  onMove,
+  onClose,
+}: {
+  tag: ITag;
+  allTags: ITag[];
+  onMove: (newParentId: string | null) => void;
+  onClose: () => void;
+}) {
+  const forbidden = getSubtreeIds(allTags, tag.id);
+  const candidates = allTags.filter((t) => !forbidden.has(t.id));
+
+  const choose = (id: string | null) => {
+    onClose();
+    if (id !== tag.parentId) onMove(id);
+  };
+
+  return (
+    <div className="w-80 rounded-md border bg-popover shadow-md">
+      <Command>
+        <CommandInput
+          autoFocus
+          placeholder="Search tags…"
+          onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
+        />
+        <CommandList>
+          <CommandEmpty>No matching tags.</CommandEmpty>
+          <CommandGroup>
+            <CommandItem value="__top-level__" onSelect={() => choose(null)}>
+              {tag.parentId === null && <Check size={14} className="mr-2" />}
+              <span className={tag.parentId === null ? "" : "ml-6"}>— Top level —</span>
+            </CommandItem>
+            {candidates.map((c) => (
+              <CommandItem key={c.id} value={c.value} onSelect={() => choose(c.id)}>
+                {tag.parentId === c.id && <Check size={14} className="mr-2" />}
+                <span className={tag.parentId === c.id ? "" : "ml-6"}>{c.value}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    </div>
+  );
+}

--- a/src/components/tag-manager/TagRow.tsx
+++ b/src/components/tag-manager/TagRow.tsx
@@ -1,0 +1,227 @@
+import React, { useRef, useState } from "react";
+import {
+  ChevronDown, ChevronRight, FolderTree, Loader2, MoreVertical, Plus,
+  Tag as TagIcon, Trash2,
+} from "lucide-react";
+
+import { AlertDialog, IAlertDialogActions } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { useConfig } from "@/contexts/ConfigContext";
+import { ITag } from "@/handlers/api/tag.handler";
+import { getSubtreeIds } from "@/lib/tag-manager/tree";
+
+import MovePopover from "@/components/tag-manager/MovePopover";
+
+const leafOf = (value: string) => value.slice(value.lastIndexOf("/") + 1);
+
+export interface ITagRowActions {
+  onRename: (tag: ITag, newName: string) => void;
+  onRecolor: (tag: ITag, color: string | null) => void;
+  onMove: (tag: ITag, newParentId: string | null) => void;
+  onDelete: (tag: ITag) => void;
+  onAddChild: (parentId: string, name: string) => void;
+  /** Ids currently in flight (rename/move/delete/add) — disables that row's controls. */
+  busyIds: Set<string>;
+}
+
+export default function TagRow({
+  tag,
+  allTags,
+  childrenOf,
+  visibleIds,
+  depth,
+  expanded,
+  toggleExpanded,
+  actions,
+}: {
+  tag: ITag;
+  allTags: ITag[];
+  childrenOf: Map<string | null, ITag[]>;
+  visibleIds: Set<string> | null;
+  depth: number;
+  expanded: Set<string>;
+  toggleExpanded: (id: string) => void;
+  actions: ITagRowActions;
+}) {
+  const { exImmichUrl } = useConfig();
+  const [editing, setEditing] = useState(false);
+  const [draftName, setDraftName] = useState(leafOf(tag.value));
+  const [addingChild, setAddingChild] = useState(false);
+  const [childName, setChildName] = useState("");
+  const [moving, setMoving] = useState(false);
+  const deleteDialogRef = useRef<IAlertDialogActions>(null);
+
+  const allChildren = childrenOf.get(tag.id) ?? [];
+  const children = visibleIds ? allChildren.filter((c) => visibleIds.has(c.id)) : allChildren;
+  const isOpen = expanded.has(tag.id) || (visibleIds !== null && children.length > 0);
+  const busy = actions.busyIds.has(tag.id);
+  const descendantCount = getSubtreeIds(allTags, tag.id).size - 1;
+
+  const commitRename = () => {
+    setEditing(false);
+    const trimmed = draftName.trim();
+    if (trimmed && trimmed !== leafOf(tag.value)) actions.onRename(tag, trimmed);
+    else setDraftName(leafOf(tag.value));
+  };
+
+  const commitAddChild = () => {
+    const trimmed = childName.trim();
+    if (trimmed) actions.onAddChild(tag.id, trimmed);
+    setChildName("");
+    setAddingChild(false);
+  };
+
+  return (
+    <div>
+      <div
+        className="group flex items-center gap-1 rounded-md px-1 py-1 hover:bg-muted/50"
+        style={{ paddingLeft: depth * 20 }}
+      >
+        <button
+          className="flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground disabled:opacity-0"
+          disabled={!allChildren.length}
+          onClick={() => toggleExpanded(tag.id)}
+        >
+          {allChildren.length > 0 && (isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />)}
+        </button>
+
+        <span
+          className="relative flex h-4 w-4 shrink-0 items-center justify-center"
+          title={tag.color ? `Tag color: ${tag.color} — click to change` : "Click to set a color"}
+        >
+          <TagIcon
+            size={14}
+            className={tag.color ? undefined : "text-muted-foreground"}
+            style={tag.color ? { color: tag.color } : undefined}
+            fill={tag.color || "none"}
+          />
+          <input
+            type="color"
+            value={tag.color || "#71717a"}
+            aria-label="Tag color"
+            className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            onChange={(e) => actions.onRecolor(tag, e.target.value)}
+            disabled={busy}
+          />
+        </span>
+
+        {editing ? (
+          <Input
+            autoFocus
+            value={draftName}
+            onChange={(e) => setDraftName(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitRename();
+              else if (e.key === "Escape") { setDraftName(leafOf(tag.value)); setEditing(false); }
+            }}
+            className="h-6 min-w-0 flex-1 text-sm"
+          />
+        ) : (
+          <span
+            className="min-w-0 flex-1 cursor-text truncate rounded px-1 text-sm hover:bg-muted"
+            title="Click to rename"
+            onClick={() => !busy && setEditing(true)}
+          >
+            {leafOf(tag.value)}
+          </span>
+        )}
+
+        {busy && <Loader2 size={13} className="shrink-0 animate-spin text-muted-foreground" />}
+
+        <a
+          href={`${exImmichUrl}/tags?path=${encodeURIComponent(tag.value)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={`View ${tag.assetCount.toLocaleString()} photo${tag.assetCount === 1 ? "" : "s"} in Immich`}
+          className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-primary/20 hover:text-primary"
+        >
+          {tag.assetCount.toLocaleString()}
+        </a>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button size="sm" variant="ghost" className="h-7 w-7 shrink-0 p-0" title="More actions" disabled={busy}>
+              <MoreVertical size={14} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => setAddingChild(true)}>
+              <Plus size={14} className="mr-2" /> Add sub-tag
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setMoving(true)}>
+              <FolderTree size={14} className="mr-2" /> Move to…
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-red-500 focus:text-red-500"
+              // Deferred a tick: opening the AlertDialog synchronously here
+              // races the DropdownMenu's own close/focus-return, which can
+              // leave the confirm dialog un-openable.
+              onSelect={() => setTimeout(() => deleteDialogRef.current?.open(), 0)}
+            >
+              <Trash2 size={14} className="mr-2" /> Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <AlertDialog
+          ref={deleteDialogRef}
+          title={`Delete "${leafOf(tag.value)}"?`}
+          description={
+            descendantCount > 0
+              ? `This tag has ${descendantCount} sub-tag${descendantCount === 1 ? "" : "s"} and is on ${tag.assetCount.toLocaleString()} photo${tag.assetCount === 1 ? "" : "s"}. Deleting it deletes the sub-tags too (Immich cascades this). Photos themselves are never touched, only the tag. This can't be undone.`
+              : `This tag is on ${tag.assetCount.toLocaleString()} photo${tag.assetCount === 1 ? "" : "s"}. Photos themselves are never touched, only the tag. This can't be undone.`
+          }
+          onConfirm={() => actions.onDelete(tag)}
+        />
+      </div>
+
+      {addingChild && (
+        <div className="flex items-center gap-2 py-1" style={{ paddingLeft: (depth + 1) * 20 + 24 }}>
+          <Input
+            autoFocus
+            value={childName}
+            onChange={(e) => setChildName(e.target.value)}
+            placeholder="New sub-tag name…"
+            className="h-6 w-48 text-sm"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitAddChild();
+              else if (e.key === "Escape") { setChildName(""); setAddingChild(false); }
+            }}
+            onBlur={() => { if (!childName.trim()) setAddingChild(false); }}
+          />
+        </div>
+      )}
+
+      {moving && (
+        <div className="py-1" style={{ paddingLeft: (depth + 1) * 20 + 24 }}>
+          <MovePopover
+            tag={tag}
+            allTags={allTags}
+            onMove={(p) => actions.onMove(tag, p)}
+            onClose={() => setMoving(false)}
+          />
+        </div>
+      )}
+
+      {isOpen && children.map((child) => (
+        <TagRow
+          key={child.id}
+          tag={child}
+          allTags={allTags}
+          childrenOf={childrenOf}
+          visibleIds={visibleIds}
+          depth={depth + 1}
+          expanded={expanded}
+          toggleExpanded={toggleExpanded}
+          actions={actions}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/config/constants/sidebarNavs.tsx
+++ b/src/config/constants/sidebarNavs.tsx
@@ -1,4 +1,4 @@
-import { Copy, GalleryHorizontal, GalleryVerticalEnd, Image as ImageIcon, MapPin, MapPinX, PackageSearch, Rewind, Search, Settings, Share2, User, Video, Workflow } from "lucide-react";
+import { Copy, GalleryHorizontal, GalleryVerticalEnd, Image as ImageIcon, MapPin, MapPinX, PackageSearch, Rewind, Search, Settings, Share2, Tags, User, Video, Workflow } from "lucide-react";
 
 interface SidebarNav {
   title: string;
@@ -30,6 +30,7 @@ export const sidebarGroups: SidebarGroup[] = [
       { title: "Empty Videos", link: "/assets/empty-videos", icon: <Video className="h-4 w-4" /> },
       { title: "Bulk Duplicate Finder", link: "/assets/bulk-duplicate-finder", icon: <Copy className="h-4 w-4" /> },
       { title: "Orphan Finder", link: "/assets/orphan-finder", icon: <PackageSearch className="h-4 w-4" /> },
+      { title: "Tag Manager", link: "/tags", icon: <Tags className="h-4 w-4" />, badge: "Beta" },
     ],
   },
   {

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -8,6 +8,14 @@ export const LOGOUT_PATH = BASE_API_ENDPOINT + "/users/logout";
 
 export const LIST_PEOPLE_PATH = BASE_API_ENDPOINT + "/people/list";
 export const LIST_TAGS_PATH = BASE_API_ENDPOINT + "/tags";
+// Create-or-get a tag by name, and single-tag delete/color-update — both
+// proxied straight to Immich with the requesting user's own session.
+export const CREATE_OR_GET_TAG_PATH = BASE_PROXY_ENDPOINT + "/tags";
+export const TAG_PATH = (tagId: string) => BASE_PROXY_ENDPOINT + "/tags/" + tagId;
+// Rename / nest / un-nest go through this app's own endpoint — Immich v3's
+// tag update can't change name or parentId, so those recreate the tag (see
+// lib/tag-manager/move.ts).
+export const MOVE_TAG_PATH = (tagId: string) => BASE_API_ENDPOINT + "/tags/" + tagId + "/move";
 export const SEARCH_PEOPLE_PATH = BASE_PROXY_ENDPOINT + "/search/person";
 export const SIMILAR_FACES_PATH = (id: string) => BASE_API_ENDPOINT + "/people/" + id + "/similar-faces";
 export const PERSON_THUBNAIL_PATH = (id: string) => BASE_PROXY_ENDPOINT + "/thumbnail/" + id;

--- a/src/handlers/api/tag.handler.ts
+++ b/src/handlers/api/tag.handler.ts
@@ -1,4 +1,4 @@
-import { LIST_TAGS_PATH } from "@/config/routes";
+import { CREATE_OR_GET_TAG_PATH, LIST_TAGS_PATH, MOVE_TAG_PATH, TAG_PATH } from "@/config/routes";
 import API from "@/lib/api";
 
 export interface ITag {
@@ -6,8 +6,24 @@ export interface ITag {
   value: string;
   color: string | null;
   parentId: string | null;
+  assetCount: number;
 }
 
 export const listTags = (): Promise<{ tags: ITag[] }> => {
   return API.get(LIST_TAGS_PATH);
 };
+
+export const createTag = (params: { name: string; parentId?: string; color?: string }): Promise<ITag> =>
+  API.post(CREATE_OR_GET_TAG_PATH, params);
+
+export const deleteTag = (id: string): Promise<void> => API.delete(TAG_PATH(id));
+
+export const updateTagColor = (id: string, color: string | null): Promise<ITag> =>
+  API.patch(TAG_PATH(id), { color });
+
+/** Rename and/or move a tag (and its sub-tags) — see lib/tag-manager/move.ts. */
+export const moveTag = (
+  id: string,
+  params: { newParentId?: string | null; newName?: string }
+): Promise<{ newId: string; tagsMoved: number; assetsCopied: number }> =>
+  API.post(MOVE_TAG_PATH(id), params);

--- a/src/lib/tag-manager/move.ts
+++ b/src/lib/tag-manager/move.ts
@@ -1,0 +1,182 @@
+import { sql } from "drizzle-orm";
+
+import { db } from "@/config/db";
+import { ENV } from "@/config/environment";
+import { getUserHeaders } from "@/helpers/user.helper";
+import { IUser } from "@/types/user";
+
+/**
+ * Rename / nest / un-nest a tag (and, if it has any, its whole sub-tree).
+ *
+ * Immich v3's tag API cannot do either of these directly — verified live
+ * against the server: its update endpoint's schema (TagUpdateDto) only
+ * accepts `color`; sending a new name or parentId hits a server bug (empty
+ * SQL SET clause -> 500). Create, delete, and color updates all work fine.
+ *
+ * So this recreates the tag(s) at the new name/location via the *supported*
+ * endpoints, copies over which assets were tagged, then deletes the old
+ * tag (Immich cascades that delete to any old descendants, their tag_asset
+ * rows, and its internal tag_closure rows in one shot). Never touches
+ * Immich's database directly for writes — only the reads (which asset ids
+ * are on a tag, which tags form the sub-tree) go direct-to-Postgres, same
+ * boundary every other module in this app already follows.
+ *
+ * A moved/renamed tag gets a new id as a side effect; everything visible
+ * (name, position, tagged photos) comes out correct.
+ */
+
+const API_BATCH_SIZE = 1000;
+
+interface SubtreeNode {
+  id: string;
+  value: string;
+  parentId: string | null;
+  color: string | null;
+}
+
+async function immichFetch(path: string, method: string, body: any, user: IUser): Promise<any> {
+  const res = await fetch(`${ENV.IMMICH_URL}/api${path}`, {
+    method,
+    headers: getUserHeaders(user),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Immich API error ${res.status} on ${method} ${path}: ${text}`);
+  }
+  const contentType = res.headers.get("content-type");
+  return contentType?.includes("application/json") ? res.json() : null;
+}
+
+async function fetchSubtree(rootId: string, ownerId: string): Promise<SubtreeNode[]> {
+  const { rows } = await db.execute(sql`
+    WITH RECURSIVE subtree AS (
+      SELECT id::text, value, "parentId"::text AS "parentId", color
+        FROM "tag"
+       WHERE id = ${rootId} AND "userId" = ${ownerId}
+      UNION ALL
+      SELECT t.id::text, t.value, t."parentId"::text AS "parentId", t.color
+        FROM "tag" t
+        JOIN subtree s ON t."parentId"::text = s.id
+    )
+    SELECT * FROM subtree
+  `);
+  return rows as unknown as SubtreeNode[];
+}
+
+async function fetchAssetIds(tagId: string, ownerId: string): Promise<string[]> {
+  const { rows } = await db.execute(sql`
+    SELECT ta."assetId"::text AS "assetId"
+      FROM "tag_asset" ta
+      JOIN "asset" a ON a.id = ta."assetId" AND a."ownerId" = ${ownerId} AND a."deletedAt" IS NULL
+     WHERE ta."tagId" = ${tagId}
+  `);
+  return (rows as any[]).map((r) => r.assetId);
+}
+
+const leafOf = (value: string) => value.slice(value.lastIndexOf("/") + 1);
+
+export async function moveTag({
+  tagId,
+  ownerId,
+  user,
+  newParentId,
+  newName,
+}: {
+  tagId: string;
+  ownerId: string;
+  user: IUser;
+  /** undefined = keep current parent; null = make top-level; string = new parent tag id. */
+  newParentId?: string | null;
+  /** undefined = keep current leaf name. */
+  newName?: string;
+}): Promise<{ newId: string; tagsMoved: number; assetsCopied: number }> {
+  const subtree = await fetchSubtree(tagId, ownerId);
+  const root = subtree.find((n) => n.id === tagId);
+  if (!root) throw new Error("Tag not found");
+
+  if (newName !== undefined) {
+    const trimmed = newName.trim();
+    if (!trimmed) throw new Error("Name can't be empty");
+    if (trimmed.includes("/")) throw new Error("Tag names can't contain '/'");
+    newName = trimmed;
+  }
+
+  const subtreeIds = new Set(subtree.map((n) => n.id));
+  if (newParentId) {
+    if (subtreeIds.has(newParentId)) {
+      throw new Error("Can't nest a tag under itself or one of its own sub-tags");
+    }
+    const { rows } = await db.execute(sql`
+      SELECT 1 FROM "tag" WHERE id = ${newParentId} AND "userId" = ${ownerId} LIMIT 1
+    `);
+    if (!rows.length) throw new Error("Target parent tag not found");
+  }
+
+  const rootNewParentId = newParentId === undefined ? root.parentId : newParentId;
+  const rootNewName = newName ?? leafOf(root.value);
+
+  const createdIds: string[] = [];
+  const oldToNew = new Map<string, string>();
+
+  try {
+    // Top-down: a node's new parent must exist before the node is created.
+    const created = await immichFetch("/tags", "POST", {
+      name: rootNewName,
+      parentId: rootNewParentId || undefined,
+      color: root.color || undefined,
+    }, user);
+    oldToNew.set(root.id, created.id);
+    createdIds.push(created.id);
+
+    const byParent = new Map<string, SubtreeNode[]>();
+    for (const n of subtree) {
+      if (n.id === root.id) continue;
+      const list = byParent.get(n.parentId as string) ?? [];
+      list.push(n);
+      byParent.set(n.parentId as string, list);
+    }
+    // BFS from root so every node's old parent has already been recreated.
+    let frontier = [root.id];
+    while (frontier.length) {
+      const next: string[] = [];
+      for (const oldParentId of frontier) {
+        for (const child of byParent.get(oldParentId) ?? []) {
+          const childCreated = await immichFetch("/tags", "POST", {
+            name: leafOf(child.value),
+            parentId: oldToNew.get(oldParentId),
+            color: child.color || undefined,
+          }, user);
+          oldToNew.set(child.id, childCreated.id);
+          createdIds.push(childCreated.id);
+          next.push(child.id);
+        }
+      }
+      frontier = next;
+    }
+
+    // Copy asset tagging from each old node onto its new counterpart.
+    let assetsCopied = 0;
+    for (const node of subtree) {
+      const assetIds = await fetchAssetIds(node.id, ownerId);
+      const newId = oldToNew.get(node.id)!;
+      for (let i = 0; i < assetIds.length; i += API_BATCH_SIZE) {
+        const batch = assetIds.slice(i, i + API_BATCH_SIZE);
+        await immichFetch(`/tags/${newId}/assets`, "PUT", { ids: batch }, user);
+        assetsCopied += batch.length;
+      }
+    }
+
+    // Only remove the old tree once every new tag + asset link exists.
+    await immichFetch(`/tags/${root.id}`, "DELETE", undefined, user);
+
+    return { newId: oldToNew.get(root.id)!, tagsMoved: subtree.length, assetsCopied };
+  } catch (error) {
+    // Best-effort rollback: deleting the new root cascades to any new
+    // children already created, so one call undoes the whole partial tree.
+    if (createdIds.length) {
+      await immichFetch(`/tags/${createdIds[0]}`, "DELETE", undefined, user).catch(() => {});
+    }
+    throw error;
+  }
+}

--- a/src/lib/tag-manager/tree.ts
+++ b/src/lib/tag-manager/tree.ts
@@ -1,0 +1,47 @@
+import { ITag } from "@/handlers/api/tag.handler";
+
+/** Client-side tree helpers over the flat tag list `value` already gives us
+ * full paths (e.g. "Vacation/Europe2024"), so no path-building needed here —
+ * just parent/child and ancestor/descendant relationships. */
+
+export function buildChildrenMap(tags: ITag[]): Map<string | null, ITag[]> {
+  const map = new Map<string | null, ITag[]>();
+  for (const t of tags) {
+    const key = t.parentId;
+    const list = map.get(key) ?? [];
+    list.push(t);
+    map.set(key, list);
+  }
+  for (const list of map.values()) list.sort((a, b) => a.value.localeCompare(b.value));
+  return map;
+}
+
+/** id + every descendant, transitively — the set a tag can't be nested under (would create a cycle). */
+export function getSubtreeIds(tags: ITag[], rootId: string): Set<string> {
+  const byParent = buildChildrenMap(tags);
+  const ids = new Set([rootId]);
+  let frontier = [rootId];
+  while (frontier.length) {
+    const next: string[] = [];
+    for (const id of frontier) {
+      for (const child of byParent.get(id) ?? []) {
+        ids.add(child.id);
+        next.push(child.id);
+      }
+    }
+    frontier = next;
+  }
+  return ids;
+}
+
+/** Every ancestor id of a tag, root-first. */
+export function getAncestorIds(tags: ITag[], id: string): string[] {
+  const byId = new Map(tags.map((t) => [t.id, t]));
+  const ancestors: string[] = [];
+  let cur = byId.get(id)?.parentId ?? null;
+  while (cur) {
+    ancestors.unshift(cur);
+    cur = byId.get(cur)?.parentId ?? null;
+  }
+  return ancestors;
+}

--- a/src/pages/api/tags/[id]/move.ts
+++ b/src/pages/api/tags/[id]/move.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
+import { moveTag } from "@/lib/tag-manager/move";
+
+/** Rename and/or reparent a tag — see lib/tag-manager/move.ts for why this can't be a simple PATCH. */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method Not Allowed" });
+
+  const tagId = String(req.query.id || "");
+  if (!/^[0-9a-f-]{36}$/i.test(tagId)) return res.status(400).json({ error: "Invalid tag id" });
+
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser?.id) return res.status(401).json({ error: "Not authenticated" });
+
+  const { newParentId, newName } = req.body || {};
+  if (newParentId !== undefined && newParentId !== null && typeof newParentId !== "string") {
+    return res.status(400).json({ error: "newParentId must be a string, null, or omitted" });
+  }
+  if (newName !== undefined && typeof newName !== "string") {
+    return res.status(400).json({ error: "newName must be a string or omitted" });
+  }
+
+  try {
+    const result = await moveTag({
+      tagId,
+      ownerId: currentUser.id,
+      user: currentUser,
+      newParentId,
+      newName,
+    });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    return res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/tags/index.ts
+++ b/src/pages/api/tags/index.ts
@@ -1,8 +1,8 @@
+import { sql } from "drizzle-orm";
+import type { NextApiRequest, NextApiResponse } from "next";
+
 import { db } from "@/config/db";
 import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
-import { tags } from "@/schema";
-import { asc, eq } from "drizzle-orm";
-import type { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,18 +12,32 @@ export default async function handler(
     const currentUser = await getCurrentUser(req);
     if (!currentUser) return res.status(401).json({ message: "Unauthorized" });
 
-    const rows = await db
-      .select({
-        id: tags.id,
-        value: tags.value,
-        color: tags.color,
-        parentId: tags.parentId,
-      })
-      .from(tags)
-      .where(eq(tags.userId, currentUser.id))
-      .orderBy(asc(tags.value));
+    // LEFT JOIN so tags with zero (visible) photos still come back with
+    // assetCount 0 — Tag Manager wants to surface empty tags, not hide them.
+    // Trashed/soft-deleted assets leave orphaned tag_asset rows (same Immich
+    // behavior noted in face-review's queries), so they're excluded here too.
+    const { rows } = await db.execute(sql`
+      SELECT t.id::text AS id, t.value, t.color, t."parentId"::text AS "parentId",
+             COUNT(a.id) AS "assetCount"
+        FROM "tag" t
+        LEFT JOIN "tag_asset" ta ON ta."tagId" = t.id
+        LEFT JOIN "asset" a ON a.id = ta."assetId"
+                           AND a."deletedAt" IS NULL
+                           AND a.visibility IN ('timeline', 'archive')
+       WHERE t."userId" = ${currentUser.id}
+       GROUP BY t.id
+       ORDER BY t.value
+    `);
 
-    return res.status(200).json({ tags: rows });
+    const tagsOut = rows.map((r: any) => ({
+      id: r.id,
+      value: r.value,
+      color: r.color,
+      parentId: r.parentId,
+      assetCount: +r.assetCount,
+    }));
+
+    return res.status(200).json({ tags: tagsOut });
   } catch (error: any) {
     res.status(500).json({ error: error?.message });
   }

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -115,7 +115,7 @@ export default function TagManagerPage() {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search tags…"
-              className="h-8 w-64 pr-7"
+              className="h-9 w-64 pr-7"
             />
             {search && (
               <button
@@ -144,7 +144,7 @@ export default function TagManagerPage() {
               value={rootName}
               onChange={(e) => setRootName(e.target.value)}
               placeholder="New top-level tag name…"
-              className="h-8 w-64"
+              className="h-9 w-64"
               onKeyDown={(e) => {
                 if (e.key === "Enter") addRoot();
                 else if (e.key === "Escape") { setRootName(""); setAddingRoot(false); }

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -1,0 +1,184 @@
+import React, { useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Plus, X } from "lucide-react";
+import toast from "react-hot-toast";
+
+import HelpGuide from "@/components/tag-manager/HelpGuide";
+import TagRow, { ITagRowActions } from "@/components/tag-manager/TagRow";
+import PageLayout from "@/components/layouts/PageLayout";
+import Header from "@/components/shared/Header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  createTag, deleteTag, ITag, listTags, moveTag, updateTagColor,
+} from "@/handlers/api/tag.handler";
+import { buildChildrenMap, getAncestorIds } from "@/lib/tag-manager/tree";
+
+/**
+ * Tag Manager: view/search/add/remove/rename/nest/un-nest your own tags,
+ * with a photo count on each (including empty tags). Rename and nest/un-nest
+ * can't go through Immich's own API (see lib/tag-manager/move.ts for why) —
+ * they're routed through this app's /api/tags/[id]/move, which recreates the
+ * tag(s) and copies the tagging over, so the tag's id changes but everything
+ * you see (name, position, tagged photos) comes out correct.
+ */
+export default function TagManagerPage() {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState("");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
+  const [addingRoot, setAddingRoot] = useState(false);
+  const [rootName, setRootName] = useState("");
+
+  const query = useQuery({
+    queryKey: ["tags"],
+    queryFn: listTags,
+  });
+  const tags: ITag[] = query.data?.tags ?? [];
+
+  const childrenOf = useMemo(() => buildChildrenMap(tags), [tags]);
+
+  const q = search.trim().toLowerCase();
+  const visibleIds = useMemo(() => {
+    if (!q) return null;
+    const set = new Set<string>();
+    for (const t of tags) {
+      if (t.value.toLowerCase().includes(q)) {
+        set.add(t.id);
+        for (const a of getAncestorIds(tags, t.id)) set.add(a);
+      }
+    }
+    return set;
+  }, [tags, q]);
+
+  const toggleExpanded = (id: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+
+  const withBusy = async (id: string, fn: () => Promise<any>, successMsg?: string) => {
+    setBusyIds((prev) => new Set(prev).add(id));
+    try {
+      await fn();
+      if (successMsg) toast.success(successMsg);
+      await queryClient.invalidateQueries({ queryKey: ["tags"] });
+    } catch (e: any) {
+      toast.error(`Failed: ${e?.error || e?.message || "unknown"}`);
+    } finally {
+      setBusyIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  };
+
+  const actions: ITagRowActions = {
+    busyIds,
+    onRename: (tag, newName) =>
+      withBusy(tag.id, () => moveTag(tag.id, { newName }), "Renamed"),
+    onRecolor: (tag, color) =>
+      withBusy(tag.id, () => updateTagColor(tag.id, color)),
+    onMove: (tag, newParentId) =>
+      withBusy(tag.id, () => moveTag(tag.id, { newParentId }), newParentId ? "Nested" : "Moved to top level"),
+    onDelete: (tag) =>
+      withBusy(tag.id, () => deleteTag(tag.id), "Deleted"),
+    onAddChild: (parentId, name) =>
+      withBusy(parentId, () => createTag({ name, parentId }), `Added "${name}"`),
+  };
+
+  const addRoot = async () => {
+    const trimmed = rootName.trim();
+    if (!trimmed) { setAddingRoot(false); return; }
+    setAddingRoot(false);
+    setRootName("");
+    try {
+      await createTag({ name: trimmed });
+      toast.success(`Added "${trimmed}"`);
+      await queryClient.invalidateQueries({ queryKey: ["tags"] });
+    } catch (e: any) {
+      toast.error(`Failed: ${e?.error || e?.message || "unknown"}`);
+    }
+  };
+
+  const rootTags = (childrenOf.get(null) ?? []).filter((t) => !visibleIds || visibleIds.has(t.id));
+
+  return (
+    <PageLayout title="Tag Manager">
+      <Header leftComponent="Tag Manager" />
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative">
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search tags…"
+              className="h-8 w-64 pr-7"
+            />
+            {search && (
+              <button
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label="Clear search"
+                onClick={() => setSearch("")}
+              >
+                <X size={14} />
+              </button>
+            )}
+          </div>
+          <Button size="sm" variant="outline" onClick={() => setAddingRoot((v) => !v)}>
+            <Plus size={14} className="mr-1" /> New tag
+          </Button>
+          <span className="text-xs text-muted-foreground">Click a name to rename · counts include empty tags</span>
+          <HelpGuide />
+          <span className="ml-auto text-sm text-muted-foreground">
+            {tags.length.toLocaleString()} tag{tags.length === 1 ? "" : "s"}
+          </span>
+        </div>
+
+        {addingRoot && (
+          <div className="flex items-center gap-2">
+            <Input
+              autoFocus
+              value={rootName}
+              onChange={(e) => setRootName(e.target.value)}
+              placeholder="New top-level tag name…"
+              className="h-8 w-64"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") addRoot();
+                else if (e.key === "Escape") { setRootName(""); setAddingRoot(false); }
+              }}
+              onBlur={() => { if (!rootName.trim()) setAddingRoot(false); }}
+            />
+          </div>
+        )}
+
+        {query.isLoading ? (
+          <div className="flex justify-center py-16"><Loader2 className="animate-spin" /></div>
+        ) : !tags.length ? (
+          <div className="py-16 text-center text-muted-foreground">No tags yet.</div>
+        ) : !rootTags.length ? (
+          <div className="py-16 text-center text-muted-foreground">No tags match &ldquo;{search}&rdquo;.</div>
+        ) : (
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-2 items-start">
+            {rootTags.map((tag) => (
+              <div key={tag.id} className="rounded-lg border p-2">
+                <TagRow
+                  tag={tag}
+                  allTags={tags}
+                  childrenOf={childrenOf}
+                  visibleIds={visibleIds}
+                  depth={0}
+                  expanded={expanded}
+                  toggleExpanded={toggleExpanded}
+                  actions={actions}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </PageLayout>
+  );
+}


### PR DESCRIPTION
## What this adds

A **Tag Manager** page at **`/tags`** (sidebar: Tools → Tag Manager): view
the whole tag tree with per-tag photo counts, search it, and rename / nest /
un-nest / recolor / delete tags inline.

## The Immich v3 constraint this works around

Immich v3's tag update endpoint only accepts `color` — it **cannot** change
a tag's `name` or `parentId` (PATCHing either 500s from an empty SQL `SET`
clause). So rename / nest / un-nest are implemented by **recreating** the
tag(s) through this app's own `/api/tags/[id]/move` endpoint
(`lib/tag-manager/move.ts`).

One consequence worth calling out: a moved or renamed tag gets a **new id**.
Workflow tag conditions match by id, so a rename can silently detach them —
the in-app help dialog documents this so users aren't surprised.

## Other notes

- The tag list query uses a `LEFT JOIN` so tags with **zero** visible photos
  still appear (the whole point is to manage empty/stray tags too), and
  excludes trashed / non-viewable assets from the counts — same
  visibility handling used elsewhere in the app.
- All reads and writes use the requesting user's own session; Power Tools
  never escalates.

## Scope

New code under `src/components/tag-manager/`, `src/lib/tag-manager/`,
`src/pages/tags/index.tsx`, and `src/pages/api/tags/[id]/move.ts`. The
existing `src/pages/api/tags/index.ts` and `src/handlers/api/tag.handler.ts`
gain the count query and the move/rename/delete calls. Shared changes are one
sidebar entry and three tag route constants.

## Testing

- `tsc --noEmit` clean.
- Exercised on a live Immich v3 instance: rename, nest, un-nest, recolor,
  delete (with confirm), search, and counts — including confirming a
  rename produces a new tag id.
