### PR TITLE
feat(face-review): write layer — reassign/stranger/scan (3/4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,14 @@ COPY --from=builder --chown=nextjs:nodejs /app/src/db/migrations ./src/db/migrat
 COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@libsql ./node_modules/@libsql
 COPY --from=deps --chown=nextjs:nodejs /app/node_modules/libsql ./node_modules/libsql
 
+# Same insurance for sharp (Face Review's face-crop endpoint): its platform
+# binaries live in @img/* optional deps that standalone tracing can miss.
+# sharp itself comes via Next's optionalDependencies, not package.json.
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/sharp ./node_modules/sharp
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@img ./node_modules/@img
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/detect-libc ./node_modules/detect-libc
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/semver ./node_modules/semver
+
 RUN mkdir -p /app/data && chown nextjs:nodejs /app/data
 
 USER nextjs

--- a/src/lib/face-review/actions.ts
+++ b/src/lib/face-review/actions.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared write-path helpers: name resolution and batched face reassignment.
+ * All Immich mutations go through lib/face-review/immich.ts with the
+ * requesting user's credentials; the DB is only read here (name lookup).
+ */
+import { createPerson, reassignFace, setPersonFeatureFace } from "@/lib/face-review/immich";
+import { deleteEmptyPeople, findPersonByName, getFeatureFaceStatus, personOwnedBy } from "@/lib/face-review/queries";
+
+type ImmichUser = { isUsingAPIKey?: boolean; accessToken?: string };
+
+/**
+ * Map a typed name to a person id: exact case-insensitive match among the
+ * owner's people wins; otherwise create a new person with that name.
+ */
+export async function resolveOrCreatePerson(
+  user: ImmichUser,
+  ownerId: string,
+  name: string
+): Promise<{ id: string; matchedExisting: boolean }> {
+  const trimmed = (name || "").trim();
+  if (!trimmed) throw new Error("Empty name");
+  const existing = await findPersonByName(ownerId, trimmed);
+  if (existing) return { id: existing, matchedExisting: true };
+  const created = await createPerson(user, trimmed);
+  return { id: created.id, matchedExisting: false };
+}
+
+/**
+ * Resolve the reassign target from a request body carrying either personId
+ * or a free-typed name. A personId is verified to belong to the owner — the
+ * Immich API would also reject a foreign target, but failing early keeps the
+ * error comprehensible.
+ */
+export async function resolveTarget(
+  user: ImmichUser,
+  ownerId: string,
+  body: { personId?: string; name?: string }
+): Promise<{ id: string; matchedExisting: boolean }> {
+  if (body.personId) {
+    if (!(await personOwnedBy(body.personId, ownerId))) {
+      throw new Error("Target person not found");
+    }
+    return { id: body.personId, matchedExisting: true };
+  }
+  return resolveOrCreatePerson(user, ownerId, body.name || "");
+}
+
+/**
+ * Reassign faces one by one (no reliable bulk endpoint), tallying failures.
+ *
+ * Immich leaves the vacated source person behind even at zero faces — it
+ * never auto-deletes a person record just because its last face moved away
+ * (confirmed against a live v3 instance: reassigning a single-face person's
+ * only photo elsewhere leaves a 0-face person record sitting in "Unnamed").
+ * ownerId, when given, sweeps those empty husks after the batch — the same
+ * owner-scoped query "Delete empty people" already runs manually, just
+ * folded into the normal reassign/stranger flow so a single-face person
+ * doesn't need a separate manual cleanup click every time.
+ */
+export async function reassignFaces(
+  user: ImmichUser,
+  faceIds: string[],
+  targetPersonId: string,
+  ownerId?: string
+): Promise<{ done: number; failed: number }> {
+  let done = 0, failed = 0;
+  for (const faceId of faceIds) {
+    try {
+      await reassignFace(user, faceId, targetPersonId);
+      done++;
+    } catch {
+      failed++;
+    }
+  }
+  if (done > 0 && ownerId) await deleteEmptyPeople(ownerId).catch(() => {});
+  return { done, failed };
+}
+
+/**
+ * mergePerson() never gives the target a cover photo if it had none — unlike
+ * Immich's own per-face reassign endpoints, which self-heal a null
+ * faceAssetId by picking a random remaining face (confirmed in Immich's
+ * person.service.js: reassignFaces()/reassignFacesById() call
+ * createNewFeaturePhoto() when faceAssetId is null; mergePerson() just
+ * reassigns faces and deletes the source, nothing else). So a person born
+ * via resolveOrCreatePerson()+mergePerson() (the "name this whole person"
+ * flow, when the typed name doesn't match anyone) is stuck with no
+ * thumbnail forever. This mirrors Immich's own self-heal: pick one of the
+ * person's own visible faces and set it as the feature face, which queues
+ * Immich's thumbnail job. No-ops if a feature face is already set.
+ */
+export async function ensurePersonThumbnail(user: ImmichUser, personId: string, ownerId: string): Promise<void> {
+  const { hasFeatureFace, sampleAssetId } = await getFeatureFaceStatus(personId, ownerId);
+  if (hasFeatureFace || !sampleAssetId) return;
+  await setPersonFeatureFace(user, personId, sampleAssetId);
+}
+
+export function parseFaceIds(body: any): string[] {
+  const ids = Array.isArray(body?.faceIds) ? body.faceIds : [];
+  return ids.filter((x: unknown) => typeof x === "string" && /^[0-9a-f-]{36}$/i.test(x as string));
+}

--- a/src/lib/face-review/cluster.ts
+++ b/src/lib/face-review/cluster.ts
@@ -1,0 +1,166 @@
+/**
+ * Face clustering engine: single-linkage connected components over the graph
+ * where an edge joins two faces iff cosine similarity >= threshold.
+ *
+ * The O(n^2) similarity pass runs in pure JS on worker_threads over a
+ * SharedArrayBuffer, with a 4-way unrolled dot product. Deliberately NOT SQL
+ * and NOT a native/WASM dependency:
+ *  - SQL was measured on live data (~5.1k-face person, Immich pgvector) at
+ *    49s (pairwise self-join) and 183s (per-face LATERAL over the ANN index —
+ *    the index can't help inside one person's rows). Unusable.
+ *  - This implementation measures ~0.8s for the same person on 8 workers
+ *    (M1 Max), matching a numpy BLAS baseline (~0.75s) with zero deps, and
+ *    produced bit-identical clusters (same 233,459 edges, 84 clusters /
+ *    1,132 singletons at threshold 0.65).
+ *
+ * The similarity matrix is never materialized: edges above threshold stream
+ * into worker-local buffers (233k edges for 5k faces vs a ~100MB matrix).
+ */
+import os from "node:os";
+import { Worker } from "node:worker_threads";
+
+export interface ClusterOptions {
+  /** Cosine similarity two faces need to land in one cluster. */
+  threshold: number;
+  /** Components smaller than this are folded into singletonCount. */
+  minClusterSize: number;
+  /** Hard ceiling — O(n^2) work; throw rather than melt on a pathological person. */
+  maxFaces?: number;
+}
+
+export interface ClusterOutput {
+  /** Each cluster is a list of row indexes into the caller's face list,
+   * largest cluster first. */
+  clusters: number[][];
+  singletonCount: number;
+}
+
+export const DEFAULT_THRESHOLD = 0.65;
+export const DEFAULT_MIN_CLUSTER_SIZE = 2;
+export const DEFAULT_MAX_FACES = 8000;
+
+// Worker source as a self-contained string: API routes are bundled by Next,
+// and an eval-worker avoids having to teach the bundler about a separate
+// worker entry file. The code is small and has no imports beyond
+// worker_threads itself.
+const WORKER_SRC = `
+const { parentPort, workerData } = require("node:worker_threads");
+const { sab, n, d, threshold, start, step } = workerData;
+const M = new Float32Array(sab);
+let cap = 1 << 16, len = 0;
+let edges = new Int32Array(cap);
+const push = (i, j) => {
+  if (len + 2 > cap) { cap *= 2; const e2 = new Int32Array(cap); e2.set(edges); edges = e2; }
+  edges[len++] = i; edges[len++] = j;
+};
+// Row-interleaved upper triangle: worker w handles rows w, w+P, w+2P, ...
+// which balances the shrinking triangle without cost modeling.
+for (let i = start; i < n; i += step) {
+  const offI = i * d;
+  for (let j = i + 1; j < n; j++) {
+    const offJ = j * d;
+    let s0 = 0, s1 = 0, s2 = 0, s3 = 0;
+    for (let k = 0; k < d; k += 4) {
+      s0 += M[offI + k]     * M[offJ + k];
+      s1 += M[offI + k + 1] * M[offJ + k + 1];
+      s2 += M[offI + k + 2] * M[offJ + k + 2];
+      s3 += M[offI + k + 3] * M[offJ + k + 3];
+    }
+    if (s0 + s1 + s2 + s3 >= threshold) push(i, j);
+  }
+}
+const out = edges.slice(0, len);
+parentPort.postMessage(out, [out.buffer]);
+`;
+
+// One clustering run at a time per process: each run already saturates the
+// machine with its own worker pool, so concurrent runs would only thrash.
+let queue: Promise<unknown> = Promise.resolve();
+function withClusterLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = queue.then(fn, fn);
+  queue = run.catch(() => {});
+  return run;
+}
+
+function workerCount(): number {
+  return Math.max(1, Math.min(8, os.cpus().length - 2));
+}
+
+/**
+ * @param embeddings row-major n x d matrix. Rows need NOT be normalized —
+ *   normalization happens here so callers can pass raw pgvector values.
+ */
+export function clusterEmbeddings(
+  embeddings: Float32Array,
+  n: number,
+  d: number,
+  opts: ClusterOptions
+): Promise<ClusterOutput> {
+  const { threshold, minClusterSize, maxFaces = DEFAULT_MAX_FACES } = opts;
+  if (n * d !== embeddings.length) {
+    throw new Error(`embeddings length ${embeddings.length} != n*d (${n}*${d})`);
+  }
+  if (n > maxFaces) {
+    throw new Error(
+      `Too many faces to cluster (${n} > ${maxFaces}) — the similarity pass is O(n^2) in time and memory.`
+    );
+  }
+  return withClusterLock(async () => {
+    if (n < 2) return { clusters: [], singletonCount: n };
+
+    // Copy into a SharedArrayBuffer, normalizing each row.
+    const sab = new SharedArrayBuffer(n * d * 4);
+    const M = new Float32Array(sab);
+    for (let i = 0; i < n; i++) {
+      const off = i * d;
+      let norm = 0;
+      for (let k = 0; k < d; k++) norm += embeddings[off + k] * embeddings[off + k];
+      norm = Math.sqrt(norm) || 1;
+      for (let k = 0; k < d; k++) M[off + k] = embeddings[off + k] / norm;
+    }
+
+    const P = workerCount();
+    const edgeLists = await Promise.all(
+      Array.from({ length: P }, (_, w) =>
+        new Promise<Int32Array>((resolve, reject) => {
+          const wk = new Worker(WORKER_SRC, {
+            eval: true,
+            workerData: { sab, n, d, threshold, start: w, step: P },
+          });
+          wk.once("message", (m: Int32Array) => { resolve(m); void wk.terminate(); });
+          wk.once("error", reject);
+        })
+      )
+    );
+
+    // Union-find over the merged edge lists (trivially fast: ~3ms / 233k edges).
+    const parent = new Int32Array(n);
+    for (let i = 0; i < n; i++) parent[i] = i;
+    const find = (x: number): number => {
+      while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; }
+      return x;
+    };
+    for (const list of edgeLists) {
+      for (let e = 0; e < list.length; e += 2) {
+        const ri = find(list[e]), rj = find(list[e + 1]);
+        if (ri !== rj) parent[ri] = rj;
+      }
+    }
+
+    const members = new Map<number, number[]>();
+    for (let i = 0; i < n; i++) {
+      const r = find(i);
+      const arr = members.get(r);
+      if (arr) arr.push(i);
+      else members.set(r, [i]);
+    }
+    const clusters: number[][] = [];
+    let singletonCount = 0;
+    for (const group of members.values()) {
+      if (group.length >= minClusterSize) clusters.push(group);
+      else singletonCount += group.length;
+    }
+    clusters.sort((a, b) => b.length - a.length);
+    return { clusters, singletonCount };
+  });
+}

--- a/src/lib/face-review/immich.ts
+++ b/src/lib/face-review/immich.ts
@@ -1,0 +1,79 @@
+/**
+ * Server-side Immich API calls for Face Review writes, made with the
+ * requesting user's own credentials (cookie session or API key) so Immich's
+ * own authorization stays authoritative for every mutation.
+ */
+import { ENV } from "@/config/environment";
+import { getUserHeaders } from "@/helpers/user.helper";
+
+type ImmichUser = { isUsingAPIKey?: boolean; accessToken?: string };
+
+async function immich(
+  user: ImmichUser,
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<any> {
+  const res = await fetch(`${ENV.IMMICH_URL}/api${path}`, {
+    method,
+    headers: getUserHeaders(user),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Immich ${method} ${path} -> ${res.status}${text ? `: ${text.slice(0, 300)}` : ""}`);
+  }
+  const ct = res.headers.get("content-type") || "";
+  return ct.includes("application/json") ? res.json() : res.text();
+}
+
+/**
+ * Reassign one detected face to a person.
+ *
+ * !! ENDPOINT SHAPE FOOTGUN — verified against a live v3 instance by the
+ * source tool after the intuitive shape failed: despite the name
+ * `PUT /faces/{id}`, the URL param is the TARGET PERSON id and the body
+ * carries the face: `{"id": "<faceId>"}`. Getting this backwards reassigns
+ * the wrong entity. Do not "fix" the argument order.
+ */
+export function reassignFace(user: ImmichUser, faceId: string, targetPersonId: string) {
+  return immich(user, "PUT", `/faces/${targetPersonId}`, { id: faceId });
+}
+
+export function createPerson(user: ImmichUser, name = ""): Promise<{ id: string; name: string }> {
+  return immich(user, "POST", "/people", { name });
+}
+
+export function updatePersonName(user: ImmichUser, personId: string, name: string) {
+  return immich(user, "PUT", `/people/${personId}`, { name });
+}
+
+/** Sets the person's cover-photo source face; Immich queues its own thumbnail-generation job as a side effect. */
+export function setPersonFeatureFace(user: ImmichUser, personId: string, assetId: string) {
+  return immich(user, "PUT", `/people/${personId}`, { featureFaceAssetId: assetId });
+}
+
+export function mergePerson(user: ImmichUser, targetId: string, sourceIds: string[]) {
+  return immich(user, "POST", `/people/${targetId}/merge`, { ids: sourceIds });
+}
+
+/**
+ * Queue Facial Recognition in MISSING mode. Never force=true: "All"
+ * re-clusters from scratch and can overwrite manual corrections (documented
+ * Immich behavior). Also note: job commands are PUT /jobs/{name} — POST is
+ * a different endpoint entirely.
+ */
+export function runFacialRecognitionMissing(user: ImmichUser) {
+  return immich(user, "PUT", "/jobs/facialRecognition", { command: "start", force: false });
+}
+
+export function getJobStatus(user: ImmichUser) {
+  return immich(user, "GET", "/jobs");
+}
+
+export const STRANGER_PREFIX = "Stranger ";
+
+/** Unique per-split label, e.g. "Stranger 3f9a" — same scheme as the source tool. */
+export function strangerName(): string {
+  return `${STRANGER_PREFIX}${crypto.randomUUID().replace(/-/g, "").slice(0, 4)}`;
+}

--- a/src/lib/face-review/queries.ts
+++ b/src/lib/face-review/queries.ts
@@ -1,0 +1,462 @@
+/**
+ * Face Review read queries. Ported from the standalone immich-face-review
+ * tool's db.py, whose non-obvious behaviors were verified against a live
+ * multi-user Immich v3 instance. Two rules carried over verbatim:
+ *
+ * 1. OWNER SCOPING IS MANDATORY. The person/asset tables are instance-wide;
+ *    every query keyed by an id from the URL either takes ownerId or sits
+ *    behind personOwnedBy(). Destructive ops fail closed without an owner.
+ * 2. Trashed assets leave orphaned asset_face rows behind (Immich soft
+ *    delete), which break API reassignment and skew centroid math — every
+ *    query filters a."deletedAt" IS NULL.
+ *
+ * "Confidence" here = cosine distance from the person's centroid embedding
+ * (Immich does not persist detection confidence; embeddings in face_search
+ * are the only signal). Higher distance = less typical = review first.
+ */
+import { sql } from "drizzle-orm";
+
+import { db } from "@/config/db";
+import {
+  clusterEmbeddings,
+  DEFAULT_MAX_FACES,
+  DEFAULT_MIN_CLUSTER_SIZE,
+  DEFAULT_THRESHOLD,
+} from "@/lib/face-review/cluster";
+import { IFaceCluster, IFaceReviewFace, IFaceReviewScope } from "@/types/faceReview";
+
+export const STRANGER_PREFIXES = ["Stranger ", "Rando "] as const;
+
+/**
+ * Only faces on assets the owner can actually SEE belong in review. Immich
+ * v3 visibility states, verified against a live instance (thumbnail + asset
+ * endpoints, owner's own credentials):
+ *   timeline -> 200, archive -> 200, locked -> 400, hidden -> 404.
+ * `locked` is the PIN-protected Locked Folder — deliberately concealed, so
+ * surfacing even its face metadata here would be a privacy leak (and its
+ * crops render as "load failed" since the thumbnail proxy 400s). `hidden`
+ * is internal (e.g. motion-photo video parts). Archived photos stay fully
+ * reviewable. This predicate must accompany EVERY join against asset.
+ */
+const VIEWABLE = sql`a.visibility IN ('timeline', 'archive')`;
+
+const toDateStr = (v: unknown): string | null => {
+  if (!v) return null;
+  const d = v instanceof Date ? v : new Date(String(v));
+  return isNaN(d.getTime()) ? null : d.toISOString().slice(0, 10);
+};
+
+const rowToFace = (r: any): IFaceReviewFace => ({
+  faceId: r.face_id,
+  assetId: r.asset_id,
+  distance: r.distance === null || r.distance === undefined ? null : Math.round(+r.distance * 10000) / 10000,
+  takenAt: toDateStr(r.taken_at),
+  boundingBoxX1: r.x1, boundingBoxY1: r.y1, boundingBoxX2: r.x2, boundingBoxY2: r.y2,
+  imageWidth: r.image_w, imageHeight: r.image_h,
+  ...(r.cur_person_id !== undefined
+    ? { curPersonId: r.cur_person_id, curName: (r.cur_name || "").trim() || null }
+    : {}),
+});
+
+/** Gate for every person-scoped route: does this person belong to this owner? */
+export async function personOwnedBy(personId: string, ownerId: string): Promise<boolean> {
+  const { rows } = await db.execute(sql`
+    SELECT 1 FROM person WHERE id = ${personId} AND "ownerId" = ${ownerId} LIMIT 1
+  `);
+  return rows.length > 0;
+}
+
+export async function getPersonMeta(personId: string, ownerId: string) {
+  const { rows } = await db.execute(sql`
+    SELECT p.name, p."birthDate" AS birth_date, p."isHidden" AS is_hidden,
+           COUNT(a.id)::int AS face_count
+      FROM person p
+      LEFT JOIN asset_face af
+        ON af."personId" = p.id AND af."isVisible" = true AND af."deletedAt" IS NULL
+      LEFT JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE}
+     WHERE p.id = ${personId} AND p."ownerId" = ${ownerId}
+     GROUP BY p.id
+  `);
+  const r: any = rows[0];
+  if (!r) return null;
+  return {
+    name: (r.name || "").trim(),
+    birthDate: toDateStr(r.birth_date),
+    isHidden: !!r.is_hidden,
+    faceCount: +r.face_count,
+  };
+}
+
+const CENTROID_CTE = (personId: string) => sql`
+  WITH centroid AS (
+    SELECT AVG(fs.embedding) AS c
+      FROM asset_face af
+      JOIN face_search fs ON fs."faceId" = af.id
+      JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE}
+     WHERE af."personId" = ${personId}
+       AND af."isVisible" = true AND af."deletedAt" IS NULL
+  )
+`;
+
+export type IRankedSort = "confidence" | "recent" | "oldest";
+
+/**
+ * A person's own faces for the Tagged Faces grid. sort=confidence ranks
+ * least-typical first (centroid distance DESC); date sorts come straight
+ * from the DB (the Flask tool needed an N+1 Immich-API fallback for these —
+ * with drizzle in-process there's no reason to leave the DB).
+ * prebirthOnly limits to faces on photos captured before person.birthDate
+ * (camera-local date; UTC fileCreatedAt only as fallback).
+ */
+export async function getRankedFaces(
+  personId: string,
+  ownerId: string,
+  opts: { page: number; perPage: number; sort: IRankedSort; prebirthOnly?: boolean }
+): Promise<{ faces: IFaceReviewFace[]; total: number }> {
+  const { page, perPage, sort, prebirthOnly } = opts;
+  const orderBy =
+    sort === "recent" ? sql`taken_at DESC NULLS LAST`
+    : sort === "oldest" ? sql`taken_at ASC NULLS LAST`
+    : sql`distance DESC NULLS LAST`;
+  const prebirth = prebirthOnly
+    ? sql`AND p."birthDate" IS NOT NULL
+          AND COALESCE(a."localDateTime", a."fileCreatedAt")::date < p."birthDate"`
+    : sql``;
+  const { rows } = await db.execute(sql`
+    ${CENTROID_CTE(personId)}
+    SELECT af.id::text AS face_id, af."assetId"::text AS asset_id,
+           (fs.embedding <=> centroid.c) AS distance,
+           af."boundingBoxX1" AS x1, af."boundingBoxY1" AS y1,
+           af."boundingBoxX2" AS x2, af."boundingBoxY2" AS y2,
+           af."imageWidth" AS image_w, af."imageHeight" AS image_h,
+           COALESCE(a."localDateTime", a."fileCreatedAt") AS taken_at,
+           COUNT(*) OVER()::int AS total
+      FROM asset_face af
+      LEFT JOIN face_search fs ON fs."faceId" = af.id
+      JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE} AND a."ownerId" = ${ownerId}
+      JOIN person p ON p.id = af."personId"
+      CROSS JOIN centroid
+     WHERE af."personId" = ${personId}
+       AND af."isVisible" = true AND af."deletedAt" IS NULL
+       ${prebirth}
+     ORDER BY ${orderBy}
+     LIMIT ${perPage} OFFSET ${(page - 1) * perPage}
+  `);
+  const total = rows.length ? +(rows[0] as any).total : 0;
+  return { faces: rows.map(rowToFace), total };
+}
+
+interface EmbeddedFaceRow { face: IFaceReviewFace; emb: string }
+
+async function fetchOwnFaceEmbeddings(personId: string, ownerId: string): Promise<EmbeddedFaceRow[]> {
+  const { rows } = await db.execute(sql`
+    ${CENTROID_CTE(personId)}
+    SELECT af.id::text AS face_id, af."assetId"::text AS asset_id,
+           (fs.embedding <=> centroid.c) AS distance,
+           af."boundingBoxX1" AS x1, af."boundingBoxY1" AS y1,
+           af."boundingBoxX2" AS x2, af."boundingBoxY2" AS y2,
+           af."imageWidth" AS image_w, af."imageHeight" AS image_h,
+           COALESCE(a."localDateTime", a."fileCreatedAt") AS taken_at,
+           fs.embedding::text AS emb
+      FROM asset_face af
+      JOIN face_search fs ON fs."faceId" = af.id
+      JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE} AND a."ownerId" = ${ownerId}
+      CROSS JOIN centroid
+     WHERE af."personId" = ${personId}
+       AND af."isVisible" = true AND af."deletedAt" IS NULL
+  `);
+  return rows.map((r: any) => ({ face: rowToFace(r), emb: r.emb }));
+}
+
+function parseEmbeddings(rows: EmbeddedFaceRow[]): { M: Float32Array; d: number } {
+  const first: number[] = JSON.parse(rows[0].emb);
+  const d = first.length;
+  const M = new Float32Array(rows.length * d);
+  M.set(first, 0);
+  for (let i = 1; i < rows.length; i++) {
+    const v: number[] = JSON.parse(rows[i].emb);
+    M.set(v, i * d);
+  }
+  return { M, d };
+}
+
+function toClusterList(
+  groups: number[][],
+  rows: EmbeddedFaceRow[],
+  sortByMeanDistance: boolean
+): IFaceCluster[] {
+  const clusters = groups.map((group) => {
+    const faces = group.map((i) => rows[i].face);
+    const dists = faces.map((f) => f.distance).filter((x): x is number => x !== null);
+    const meanDistance = dists.length
+      ? Math.round((dists.reduce((a, b) => a + b, 0) / dists.length) * 10000) / 10000
+      : null;
+    return { size: faces.length, meanDistance, faces };
+  });
+  if (sortByMeanDistance) {
+    clusters.sort((a, b) => (a.meanDistance ?? Infinity) - (b.meanDistance ?? Infinity));
+  }
+  return clusters.map((c, idx) => ({ index: idx + 1, ...c }));
+}
+
+/**
+ * Cluster a person's OWN faces by mutual similarity — catches a wrongly-
+ * merged different person as a tight sub-group, the one failure mode
+ * centroid-distance ranking structurally can't see (a wrong sub-group big
+ * enough shifts the centroid toward itself).
+ */
+export async function getPersonClusters(
+  personId: string,
+  ownerId: string,
+  opts?: { threshold?: number; minClusterSize?: number; maxFaces?: number }
+): Promise<{ clusters: IFaceCluster[]; singletonCount: number; totalFaces: number; threshold: number }> {
+  const threshold = opts?.threshold ?? DEFAULT_THRESHOLD;
+  const rows = await fetchOwnFaceEmbeddings(personId, ownerId);
+  if (rows.length < 2) {
+    return { clusters: [], singletonCount: rows.length, totalFaces: rows.length, threshold };
+  }
+  const { M, d } = parseEmbeddings(rows);
+  const { clusters, singletonCount } = await clusterEmbeddings(M, rows.length, d, {
+    threshold,
+    minClusterSize: opts?.minClusterSize ?? DEFAULT_MIN_CLUSTER_SIZE,
+    maxFaces: opts?.maxFaces ?? DEFAULT_MAX_FACES,
+  });
+  // Own-face clusters: biggest first (engine default order).
+  return { clusters: toClusterList(clusters, rows, false), singletonCount, totalFaces: rows.length, threshold };
+}
+
+const scopeCondition = (scope: IFaceReviewScope) =>
+  scope === "named"
+    ? // ONLY faces already assigned to another real-named person (not
+      // empty-name, not a Stranger/Rando split-off): candidates whose "yes"
+      // explicitly moves them away from someone else.
+      sql`AND af."personId" IS NOT NULL AND p.name <> ''
+          AND p.name NOT LIKE ${STRANGER_PREFIXES[0] + "%"}
+          AND p.name NOT LIKE ${STRANGER_PREFIXES[1] + "%"}`
+    : // Unknown faces only: unassigned, empty-name person, or a stranger.
+      sql`AND (af."personId" IS NULL OR p.name = ''
+           OR p.name LIKE ${STRANGER_PREFIXES[0] + "%"}
+           OR p.name LIKE ${STRANGER_PREFIXES[1] + "%"})`;
+
+const candidateSelect = (personId: string, ownerId: string, scope: IFaceReviewScope, excludeIds: string[]) => sql`
+  ${CENTROID_CTE(personId)}
+  SELECT af.id::text AS face_id, af."assetId"::text AS asset_id,
+         (fs.embedding <=> centroid.c) AS distance,
+         af."boundingBoxX1" AS x1, af."boundingBoxY1" AS y1,
+         af."boundingBoxX2" AS x2, af."boundingBoxY2" AS y2,
+         af."imageWidth" AS image_w, af."imageHeight" AS image_h,
+         af."personId"::text AS cur_person_id, p.name AS cur_name,
+         COALESCE(a."localDateTime", a."fileCreatedAt") AS taken_at,
+         fs.embedding::text AS emb
+    FROM asset_face af
+    JOIN face_search fs ON fs."faceId" = af.id
+    JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE} AND a."ownerId" = ${ownerId}
+    LEFT JOIN person p ON p.id = af."personId"
+    CROSS JOIN centroid
+   WHERE af."isVisible" = true AND af."deletedAt" IS NULL
+     AND af."personId" IS DISTINCT FROM ${personId}::uuid
+     AND centroid.c IS NOT NULL
+     ${excludeIds.length
+       // Bound as one JSON string: drizzle/node-postgres array binding
+       // doesn't produce a valid uuid[] literal here, so unpack server-side.
+       ? sql`AND af.id <> ALL(ARRAY(SELECT jsonb_array_elements_text(${JSON.stringify(excludeIds)}::jsonb)::uuid))`
+       : sql``}
+     ${scopeCondition(scope)}
+   ORDER BY distance ASC
+`;
+
+/**
+ * "Find more of this person": faces NOT currently this person, ranked by
+ * distance to the person's centroid, closest (most likely) first. An exact
+ * scan on purpose — the ANN index returns too few rows once the person's own
+ * faces (the true nearest neighbours) are excluded. ~0.6s over ~45k faces.
+ * excludeIds carries the reviewer's browser-local reject list.
+ */
+export async function getCandidateFaces(
+  personId: string,
+  ownerId: string,
+  opts: { scope: IFaceReviewScope; excludeIds: string[]; limit: number; offset: number }
+): Promise<{ candidates: IFaceReviewFace[]; hasNext: boolean }> {
+  const { rows } = await db.execute(sql`
+    SELECT * FROM (${candidateSelect(personId, ownerId, opts.scope, opts.excludeIds)}) q
+    LIMIT ${opts.limit + 1} OFFSET ${opts.offset}
+  `);
+  const hasNext = rows.length > opts.limit;
+  return { candidates: rows.slice(0, opts.limit).map(rowToFace), hasNext };
+}
+
+export const CANDIDATE_POOL_SIZE = 2000;
+
+/**
+ * Cluster the closest CANDIDATE faces by similarity to EACH OTHER — surfaces
+ * a missed relative sitting in the pool as many separate photos as one group
+ * instead of many Yes/No decisions. Deliberately partial: only the closest
+ * poolSize candidates (full pool would be O(45k^2)); clusters sorted by mean
+ * distance ascending (most-likely first, unlike own-face clusters).
+ */
+export async function getCandidateClusters(
+  personId: string,
+  ownerId: string,
+  opts: { scope: IFaceReviewScope; excludeIds: string[]; threshold?: number; minClusterSize?: number; poolSize?: number }
+): Promise<{ clusters: IFaceCluster[]; singletonCount: number; poolSize: number; threshold: number }> {
+  const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
+  const poolSize = opts.poolSize ?? CANDIDATE_POOL_SIZE;
+  const { rows } = await db.execute(sql`
+    SELECT * FROM (${candidateSelect(personId, ownerId, opts.scope, opts.excludeIds)}) q
+    LIMIT ${poolSize}
+  `);
+  const embedded: EmbeddedFaceRow[] = rows.map((r: any) => ({ face: rowToFace(r), emb: r.emb }));
+  if (embedded.length < 2) {
+    return { clusters: [], singletonCount: embedded.length, poolSize: embedded.length, threshold };
+  }
+  const { M, d } = parseEmbeddings(embedded);
+  const { clusters, singletonCount } = await clusterEmbeddings(M, embedded.length, d, {
+    threshold,
+    minClusterSize: opts.minClusterSize ?? DEFAULT_MIN_CLUSTER_SIZE,
+    // poolSize bounds n already; no separate maxFaces ceiling here.
+    maxFaces: poolSize,
+  });
+  return {
+    clusters: toClusterList(clusters, embedded, true),
+    singletonCount,
+    poolSize: embedded.length,
+    threshold,
+  };
+}
+
+export type IFaceReviewPeopleFilter = "all" | "named" | "unnamed" | "strangers" | "hidden" | "prebirth";
+
+/** Landing-grid list: this owner's people with visible face counts. */
+export async function getPeopleWithCounts(
+  ownerId: string,
+  filter: IFaceReviewPeopleFilter
+): Promise<{ id: string; name: string; birthDate: string | null; isHidden: boolean; faceCount: number; prebirthCount?: number }[]> {
+  const nameFilter =
+    filter === "named"
+      ? sql`AND p.name <> '' AND p.name NOT LIKE ${STRANGER_PREFIXES[0] + "%"} AND p.name NOT LIKE ${STRANGER_PREFIXES[1] + "%"}`
+      : filter === "unnamed" ? sql`AND p.name = ''`
+      : filter === "strangers"
+      ? sql`AND (p.name LIKE ${STRANGER_PREFIXES[0] + "%"} OR p.name LIKE ${STRANGER_PREFIXES[1] + "%"})`
+      : sql``;
+  // Hidden people are excluded everywhere except the explicit hidden view.
+  const hiddenFilter = filter === "hidden" ? sql`AND p."isHidden" = true` : sql`AND p."isHidden" = false`;
+  const prebirthJoin =
+    filter === "prebirth"
+      ? sql`AND p."birthDate" IS NOT NULL AND COALESCE(a."localDateTime", a."fileCreatedAt")::date < p."birthDate"`
+      : sql``;
+  // face_count = COUNT(a.id): visible faces on live (non-trashed) assets.
+  // Under the prebirth filter the asset join narrows to pre-birth-date
+  // photos, so the count becomes "prebirth faces" and empty people drop out;
+  // other views keep zero-face people visible (that's what "Delete empty
+  // people" acts on).
+  const { rows } = await db.execute(sql`
+    SELECT p.id::text AS id, p.name, p."birthDate" AS birth_date, p."isHidden" AS is_hidden,
+           COUNT(a.id)::int AS face_count
+      FROM person p
+      LEFT JOIN asset_face af
+        ON af."personId" = p.id AND af."isVisible" = true AND af."deletedAt" IS NULL
+      LEFT JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE} ${prebirthJoin}
+     WHERE p."ownerId" = ${ownerId} ${nameFilter} ${hiddenFilter}
+     GROUP BY p.id
+    ${filter === "prebirth" ? sql`HAVING COUNT(a.id) > 0` : sql``}
+     ORDER BY face_count DESC, p.name ASC
+  `);
+  return rows.map((r: any) => ({
+    id: r.id,
+    name: (r.name || "").trim(),
+    birthDate: toDateStr(r.birth_date),
+    isHidden: !!r.is_hidden,
+    faceCount: +r.face_count,
+  }));
+}
+
+/** Autocomplete source + name resolution: the owner's REAL-named people. */
+export async function getNamedPeople(ownerId: string): Promise<{ id: string; name: string }[]> {
+  const { rows } = await db.execute(sql`
+    SELECT p.id::text AS id, p.name
+      FROM person p
+     WHERE p."ownerId" = ${ownerId} AND p.name <> ''
+       AND p.name NOT LIKE ${STRANGER_PREFIXES[0] + "%"}
+       AND p.name NOT LIKE ${STRANGER_PREFIXES[1] + "%"}
+     ORDER BY LOWER(p.name) ASC
+  `);
+  return rows.map((r: any) => ({ id: r.id, name: (r.name || "").trim() }));
+}
+
+/**
+ * Hide a detection that isn't a real face (statue, pet, blur): what Immich
+ * does internally for hidden faces (isVisible=false + detach) — reversible,
+ * unlike the REST DELETE /faces/{id}, which the source tool never got
+ * live-confirmed. Owner-scoped through the face's asset; PER-FACE only by
+ * design (the removed bulk variant was the accident risk).
+ * Returns false for an unknown/foreign face (no write).
+ */
+export async function hideFace(faceId: string, ownerId: string): Promise<boolean> {
+  if (!ownerId) throw new Error("ownerId required (multi-user DB, refusing unscoped update)");
+  const result = await db.execute(sql`
+    UPDATE asset_face af
+       SET "isVisible" = false, "personId" = NULL
+      FROM asset a
+     WHERE af.id = ${faceId}
+       AND a.id = af."assetId"
+       AND a."ownerId" = ${ownerId}
+       AND a."deletedAt" IS NULL
+  `);
+  return (result.rowCount ?? 0) > 0;
+}
+
+/**
+ * Delete the owner's person records with zero visible, non-deleted faces —
+ * the debris failed/retried reassigns leave behind. ownerId REQUIRED (an
+ * unscoped delete on the shared table would hit other users' records).
+ */
+export async function deleteEmptyPeople(ownerId: string): Promise<number> {
+  if (!ownerId) throw new Error("ownerId required (multi-user DB, refusing unscoped delete)");
+  const result = await db.execute(sql`
+    DELETE FROM person
+     WHERE id IN (
+       SELECT p.id FROM person p
+        WHERE p."ownerId" = ${ownerId}
+          AND NOT EXISTS (
+            SELECT 1 FROM asset_face af
+             WHERE af."personId" = p.id
+               AND af."isVisible" = true
+               AND af."deletedAt" IS NULL
+          )
+     )
+  `);
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Whether a person already has Immich's feature-face pointer set, plus one
+ * of their own visible faces' assetId to use as a fallback if not. See
+ * ensurePersonThumbnail() in actions.ts for why this is needed.
+ */
+export async function getFeatureFaceStatus(
+  personId: string,
+  ownerId: string
+): Promise<{ hasFeatureFace: boolean; sampleAssetId: string | null }> {
+  const { rows } = await db.execute(sql`
+    SELECT p."faceAssetId" IS NOT NULL AS has_feature_face,
+           (SELECT af."assetId"::text
+              FROM asset_face af
+              JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE} AND a."ownerId" = ${ownerId}
+             WHERE af."personId" = p.id AND af."isVisible" = true AND af."deletedAt" IS NULL
+             LIMIT 1) AS sample_asset_id
+      FROM person p
+     WHERE p.id = ${personId} AND p."ownerId" = ${ownerId}
+  `);
+  const r: any = rows[0];
+  return { hasFeatureFace: !!r?.has_feature_face, sampleAssetId: r?.sample_asset_id ?? null };
+}
+
+/** Exact-name match among the owner's people (case-insensitive). */
+export async function findPersonByName(ownerId: string, name: string): Promise<string | null> {
+  const { rows } = await db.execute(sql`
+    SELECT p.id::text AS id FROM person p
+     WHERE p."ownerId" = ${ownerId} AND LOWER(TRIM(p.name)) = LOWER(TRIM(${name}))
+     LIMIT 1
+  `);
+  return rows.length ? (rows[0] as any).id : null;
+}

--- a/src/lib/face-review/route-utils.ts
+++ b/src/lib/face-review/route-utils.ts
@@ -1,0 +1,50 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
+import { personOwnedBy } from "@/lib/face-review/queries";
+
+/**
+ * Resolve the request's user and verify the URL's person belongs to them.
+ * Writes the error response and returns null on failure — the multi-user
+ * Immich DB is instance-wide while auth is per-user, so every person-scoped
+ * Face Review route MUST pass this gate before touching the DB (a foreign
+ * person id must 404, indistinguishable from nonexistent).
+ */
+export interface IFaceReviewUser {
+  id: string;
+  isUsingAPIKey?: boolean;
+  accessToken?: string;
+}
+
+export async function requireOwnedPerson(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<{ ownerId: string; personId: string; user: IFaceReviewUser } | null> {
+  const personId = String(req.query.id || "");
+  if (!/^[0-9a-f-]{36}$/i.test(personId)) {
+    res.status(400).json({ error: "Invalid person id" });
+    return null;
+  }
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser?.id) {
+    res.status(401).json({ error: "Not authenticated" });
+    return null;
+  }
+  if (!(await personOwnedBy(personId, currentUser.id))) {
+    res.status(404).json({ error: "Person not found" });
+    return null;
+  }
+  return { ownerId: currentUser.id, personId, user: currentUser };
+}
+
+export async function requireUser(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<{ ownerId: string; user: IFaceReviewUser } | null> {
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser?.id) {
+    res.status(401).json({ error: "Not authenticated" });
+    return null;
+  }
+  return { ownerId: currentUser.id, user: currentUser };
+}

--- a/src/pages/api/face-review/clear-empty-people.ts
+++ b/src/pages/api/face-review/clear-empty-people.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { deleteEmptyPeople } from "@/lib/face-review/queries";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * Delete the requesting user's person records with zero visible faces —
+ * debris from failed/retried reassigns. Owner-scoped and fail-closed inside
+ * deleteEmptyPeople(); never touches another user's records.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+    const deleted = await deleteEmptyPeople(gate.ownerId);
+    return res.status(200).json({ deleted });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/faces/[faceId]/crop.ts
+++ b/src/pages/api/face-review/faces/[faceId]/crop.ts
@@ -1,0 +1,112 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { sql } from "drizzle-orm";
+import sharp from "sharp";
+
+import { db } from "@/config/db";
+import { ENV } from "@/config/environment";
+import { getUserHeaders } from "@/helpers/user.helper";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * Square face crop, rendered SERVER-side. The client used to download the
+ * asset's whole `preview` (~1440px, hundreds of KB) and crop the face on a
+ * canvas — fine on LAN, brutal remotely. Here the server (LAN-adjacent to
+ * Immich) fetches the preview, does the identical crop math (pad 40%,
+ * square, clamp — see the old FaceCrop.tsx / the source tool's faces.js),
+ * and ships only a ~500px WebP of the face itself.
+ *
+ * A face's bounding box never changes once detected, so the response is
+ * immutable — cache hard.
+ */
+
+// Display is ~200px; 400 = 2x for hi-dpi. 800 kept for possible zoom use.
+const ALLOWED_SIZES = [400, 800];
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).json({ error: "Method Not Allowed" });
+
+  const faceId = String(req.query.faceId || "");
+  if (!/^[0-9a-f-]{36}$/i.test(faceId)) {
+    return res.status(400).json({ error: "Invalid face id" });
+  }
+  const size = ALLOWED_SIZES.includes(+(req.query.s as string)) ? +(req.query.s as string) : 400;
+
+  const gate = await requireUser(req, res);
+  if (!gate) return;
+
+  try {
+    // Owner scoping via the asset join, not the person: Find More renders
+    // faces that belong to *other* (or no) person records, but always on the
+    // requesting user's own assets.
+    const { rows } = await db.execute(sql`
+      SELECT af."assetId"::text AS asset_id,
+             af."boundingBoxX1" AS x1, af."boundingBoxY1" AS y1,
+             af."boundingBoxX2" AS x2, af."boundingBoxY2" AS y2,
+             af."imageWidth" AS image_w, af."imageHeight" AS image_h
+        FROM asset_face af
+        JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND a."ownerId" = ${gate.ownerId}
+       WHERE af.id = ${faceId}
+       LIMIT 1
+    `);
+    const face = rows[0] as
+      | { asset_id: string; x1: number; y1: number; x2: number; y2: number; image_w: number; image_h: number }
+      | undefined;
+    if (!face) return res.status(404).json({ error: "Face not found" });
+
+    const upstream = await fetch(
+      `${ENV.IMMICH_URL}/api/assets/${face.asset_id}/thumbnail?size=preview`,
+      { headers: getUserHeaders(gate.user) }
+    );
+    if (!upstream.ok) {
+      return res.status(502).json({ error: `Preview fetch failed (${upstream.status})` });
+    }
+    const preview = Buffer.from(await upstream.arrayBuffer());
+
+    const img = sharp(preview);
+    const meta = await img.metadata();
+    const W = meta.width ?? 0;
+    const H = meta.height ?? 0;
+
+    let region: { left: number; top: number; width: number; height: number } | null = null;
+    const { x1, y1, x2, y2, image_w: mlW, image_h: mlH } = face;
+    if (W && H && [x1, y1, x2, y2].every((v) => typeof v === "number" && !Number.isNaN(v)) && x2 > x1) {
+      // Same math as the old client-side FaceCrop: bbox lives in the ML
+      // model's coordinate space, so scale to the preview's real size.
+      const scaleX = mlW ? W / mlW : 1;
+      const scaleY = mlH ? H / mlH : 1;
+      let sx = x1 * scaleX;
+      let sy = y1 * scaleY;
+      let sw = (x2 - x1) * scaleX;
+      let sh = (y2 - y1) * scaleY;
+      const padX = sw * 0.4, padY = sh * 0.4;
+      sx = Math.max(0, sx - padX);
+      sy = Math.max(0, sy - padY);
+      sw = Math.min(W - sx, sw + padX * 2);
+      sh = Math.min(H - sy, sh + padY * 2);
+      const cropSize = Math.min(Math.max(sw, sh), W, H);
+      sx = Math.min(Math.max(0, sx + sw / 2 - cropSize / 2), W - cropSize);
+      sy = Math.min(Math.max(0, sy + sh / 2 - cropSize / 2), H - cropSize);
+      region = {
+        left: Math.round(sx),
+        top: Math.round(sy),
+        width: Math.max(1, Math.round(cropSize)),
+        height: Math.max(1, Math.round(cropSize)),
+      };
+      // Rounding can push the region 1px past the edge; pull it back in.
+      region.width = Math.min(region.width, W - region.left);
+      region.height = Math.min(region.height, H - region.top);
+    }
+
+    const out = await (region ? img.extract(region) : img)
+      .resize(size, size, { fit: "cover" })
+      .webp({ quality: 78 })
+      .toBuffer();
+
+    res.setHeader("Content-Type", "image/webp");
+    res.setHeader("Content-Length", out.byteLength);
+    res.setHeader("Cache-Control", "private, max-age=31536000, immutable");
+    return res.send(out);
+  } catch (error: any) {
+    return res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/faces/[faceId]/not-a-face.ts
+++ b/src/pages/api/face-review/faces/[faceId]/not-a-face.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { hideFace } from "@/lib/face-review/queries";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * Hide a detection that isn't a real face. PER-FACE only, on purpose: the
+ * source tool shipped (and removed) bulk variants after nearly firing them
+ * against real family data — a deliberate one-face click stays.
+ * Direct DB write (isVisible=false + detach), owner-scoped via the asset;
+ * the REST DELETE /faces/{id} alternative was never live-confirmed there.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const faceId = String(req.query.faceId || "");
+    if (!/^[0-9a-f-]{36}$/i.test(faceId)) {
+      return res.status(400).json({ error: "Invalid face id" });
+    }
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+
+    const hidden = await hideFace(faceId, gate.ownerId);
+    if (!hidden) return res.status(404).json({ error: "Face not found" });
+    return res.status(200).json({ ok: true });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/faces/reassign.ts
+++ b/src/pages/api/face-review/faces/reassign.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { parseFaceIds, reassignFaces, resolveTarget } from "@/lib/face-review/actions";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * Reassign one or many faces to a person — the single write primitive behind
+ * per-face "This is actually …", the bulk bar, cluster confirms, and Find
+ * More's Apply. Body: { faceIds: string[], personId?: string, name?: string }
+ * (personId wins; a bare name resolves to an existing person or creates one).
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+
+    const faceIds = parseFaceIds(req.body);
+    if (!faceIds.length) return res.status(400).json({ error: "No faces given" });
+    if (!req.body?.personId && !(req.body?.name || "").trim()) {
+      return res.status(400).json({ error: "personId or name required" });
+    }
+
+    const target = await resolveTarget(gate.user, gate.ownerId, req.body);
+    const { done, failed } = await reassignFaces(gate.user, faceIds, target.id, gate.ownerId);
+    return res.status(200).json({ done, failed, personId: target.id });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/faces/stranger.ts
+++ b/src/pages/api/face-review/faces/stranger.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { parseFaceIds, reassignFaces } from "@/lib/face-review/actions";
+import { createPerson, strangerName } from "@/lib/face-review/immich";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * "I don't know this person" / "Same unknown person": split the given faces
+ * off to ONE new uniquely-named Stranger record. Fully reversible — the
+ * stranger can be reassigned or renamed any time. There is deliberately no
+ * unassign (Immich has no endpoint for it); a fresh person is the mechanism.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+
+    const faceIds = parseFaceIds(req.body);
+    if (!faceIds.length) return res.status(400).json({ error: "No faces given" });
+
+    const name = strangerName();
+    const person = await createPerson(gate.user, name);
+    const { done, failed } = await reassignFaces(gate.user, faceIds, person.id, gate.ownerId);
+    return res.status(200).json({ done, failed, personId: person.id, name });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/job-status.ts
+++ b/src/pages/api/face-review/job-status.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getJobStatus } from "@/lib/face-review/immich";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/** Facial-recognition job queue snapshot (for the scan progress pill). */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+    const status = await getJobStatus(gate.user);
+    return res.status(200).json(status?.facialRecognition ?? {});
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/names.ts
+++ b/src/pages/api/face-review/names.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getNamedPeople } from "@/lib/face-review/queries";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/** Autocomplete source: the owner's real-named people (no Strangers). */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+    const names = await getNamedPeople(gate.ownerId);
+    return res.status(200).json(names);
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/candidate-clusters.ts
+++ b/src/pages/api/face-review/people/[id]/candidate-clusters.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getCandidateClusters } from "@/lib/face-review/queries";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+import { IFaceReviewScope } from "@/types/faceReview";
+
+/**
+ * Cluster the candidate pool (closest ~2000 non-member faces) by mutual
+ * similarity — a missed relative shows up as one group instead of dozens of
+ * separate Yes/No cards. POST for the same reason as /candidates: the body
+ * carries the reject list. threshold IS reviewer-adjustable here (unlike
+ * own-face clusters) — loosening genuinely helps on a candidate pool.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const { ownerId, personId } = gate;
+
+    const body = req.body || {};
+    const scope: IFaceReviewScope = body.scope === "named" ? "named" : "unnamed";
+    const excludeIds: string[] = Array.isArray(body.exclude)
+      ? body.exclude.filter((x: unknown) => typeof x === "string" && /^[0-9a-f-]{36}$/i.test(x))
+      : [];
+    let threshold = parseFloat(String(body.threshold ?? "")) || 0.65;
+    threshold = Math.min(Math.max(threshold, 0.3), 0.95);
+
+    const result = await getCandidateClusters(personId, ownerId, { scope, excludeIds, threshold });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/candidates.ts
+++ b/src/pages/api/face-review/people/[id]/candidates.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getCandidateFaces } from "@/lib/face-review/queries";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+import { IFaceReviewScope } from "@/types/faceReview";
+
+/**
+ * "Find more of this person" feed. POST because the body carries the
+ * reviewer's browser-local reject list (exclude[]) — those faces were
+ * already judged "not them" on this device and must not reappear.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const { ownerId, personId } = gate;
+
+    const body = req.body || {};
+    const scope: IFaceReviewScope = body.scope === "named" ? "named" : "unnamed";
+    const excludeIds: string[] = Array.isArray(body.exclude)
+      ? body.exclude.filter((x: unknown) => typeof x === "string" && /^[0-9a-f-]{36}$/i.test(x))
+      : [];
+    const limit = Math.min(Math.max(1, +body.limit || 24), 100);
+    const offset = Math.max(0, +body.offset || 0);
+
+    const result = await getCandidateFaces(personId, ownerId, { scope, excludeIds, limit, offset });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/clusters.ts
+++ b/src/pages/api/face-review/people/[id]/clusters.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getPersonClusters } from "@/lib/face-review/queries";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+
+/**
+ * Own-face clusters: mutual-similarity groups inside one person's tagged
+ * faces (single-linkage over cosine similarity; see lib/face-review/cluster).
+ * threshold is accepted but the UI pins the default — kept for parity with
+ * the source tool's API and future tuning.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const { ownerId, personId } = gate;
+
+    let threshold = parseFloat(String(req.query.threshold ?? "")) || 0.65;
+    threshold = Math.min(Math.max(threshold, 0.3), 0.95);
+
+    const result = await getPersonClusters(personId, ownerId, { threshold });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    // The maxFaces ceiling throws — surface it as a client-visible 400.
+    const status = /Too many faces/.test(error?.message || "") ? 400 : 500;
+    res.status(status).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/faces.ts
+++ b/src/pages/api/face-review/people/[id]/faces.ts
@@ -1,0 +1,60 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getPersonMeta, getRankedFaces, IRankedSort } from "@/lib/face-review/queries";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+
+const SORTS: IRankedSort[] = ["confidence", "recent", "oldest"];
+const PER_PAGE = [25, 50, 100, 200];
+
+/** Tagged Faces grid: a person's own faces, least-typical-first by default. */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const { ownerId, personId } = gate;
+
+    const sort = SORTS.includes(req.query.sort as IRankedSort)
+      ? (req.query.sort as IRankedSort)
+      : "confidence";
+    const perPage = PER_PAGE.includes(+(req.query.perPage as string))
+      ? +(req.query.perPage as string)
+      : 50;
+    const prebirthOnly = req.query.show === "prebirth";
+    let page = Math.max(1, +(req.query.page as string) || 1);
+
+    const meta = await getPersonMeta(personId, ownerId);
+    if (prebirthOnly && !meta?.birthDate) {
+      return res.status(200).json({
+        faces: [], total: 0, page: 1, perPage,
+        personName: meta?.name ?? "", birthDate: null,
+      });
+    }
+
+    let result = await getRankedFaces(personId, ownerId, {
+      page, perPage,
+      // Pre-birth review is always least-typical-first, like the source tool.
+      sort: prebirthOnly ? "confidence" : sort,
+      prebirthOnly,
+    });
+    // Clamp out-of-range pages (e.g. a bulk action emptied the last page and
+    // the client re-fetched the same page number) to the real last page.
+    if (!result.faces.length && page > 1) {
+      const probe = await getRankedFaces(personId, ownerId, { page: 1, perPage, sort, prebirthOnly });
+      const lastPage = Math.max(1, Math.ceil(probe.total / perPage));
+      if (page > lastPage) {
+        page = lastPage;
+        result = page === 1 ? probe : await getRankedFaces(personId, ownerId, { page, perPage, sort, prebirthOnly });
+      }
+    }
+
+    return res.status(200).json({
+      ...result,
+      page,
+      perPage,
+      personName: meta?.name ?? "",
+      birthDate: meta?.birthDate ?? null,
+    });
+  } catch (error: any) {
+    res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/info.ts
+++ b/src/pages/api/face-review/people/[id]/info.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getPersonMeta } from "@/lib/face-review/queries";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+
+/** Review-page header data. Owner-gated (unlike the legacy people/[id]/info). */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const meta = await getPersonMeta(gate.personId, gate.ownerId);
+    if (!meta) return res.status(404).json({ error: "Person not found" });
+    return res.status(200).json({ id: gate.personId, ...meta });
+  } catch (error: any) {
+    res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/reassign-all.ts
+++ b/src/pages/api/face-review/people/[id]/reassign-all.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { ensurePersonThumbnail, resolveTarget } from "@/lib/face-review/actions";
+import { mergePerson } from "@/lib/face-review/immich";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+
+/**
+ * "This whole person is actually X": merge this person into the target.
+ * Merging into an EXISTING person is destructive-adjacent (their face sets
+ * combine), so it two-steps: without confirmMerge the route answers 409
+ * { needsConfirm: true } and the client asks the human first.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+
+    const body = req.body || {};
+    if (!body.personId && !(body.name || "").trim()) {
+      return res.status(400).json({ error: "personId or name required" });
+    }
+
+    const target = await resolveTarget(gate.user, gate.ownerId, body);
+    if (target.id === gate.personId) {
+      return res.status(400).json({ error: "That's already this person." });
+    }
+    if (target.matchedExisting && !body.confirmMerge) {
+      return res.status(409).json({
+        needsConfirm: true,
+        message: "Target already exists. Merge this person into them?",
+      });
+    }
+    await mergePerson(gate.user, target.id, [gate.personId]);
+    await ensurePersonThumbnail(gate.user, target.id, gate.ownerId).catch(() => {});
+    return res.status(200).json({ mergedInto: target.id });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/stranger-all.ts
+++ b/src/pages/api/face-review/people/[id]/stranger-all.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { strangerName, updatePersonName } from "@/lib/face-review/immich";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+
+/**
+ * "I don't know this person" for the WHOLE person: a plain rename to a
+ * unique Stranger label. Keeps the cluster intact and fully reversible —
+ * nothing moves, only the name changes.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const name = strangerName();
+    await updatePersonName(gate.user, gate.personId, name);
+    return res.status(200).json({ name });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/index.ts
+++ b/src/pages/api/face-review/people/index.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getPeopleWithCounts, IFaceReviewPeopleFilter } from "@/lib/face-review/queries";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+const FILTERS: IFaceReviewPeopleFilter[] = ["all", "named", "unnamed", "strangers", "hidden", "prebirth"];
+
+/** Face Review landing grid: this owner's people with visible-face counts. */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+
+    const filter = FILTERS.includes(req.query.filter as IFaceReviewPeopleFilter)
+      ? (req.query.filter as IFaceReviewPeopleFilter)
+      : "named";
+
+    const people = await getPeopleWithCounts(gate.ownerId, filter);
+    return res.status(200).json({ people, total: people.length });
+  } catch (error: any) {
+    res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/scan-missing.ts
+++ b/src/pages/api/face-review/scan-missing.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getJobStatus, runFacialRecognitionMissing } from "@/lib/face-review/immich";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * Queue Facial Recognition in MISSING mode (assign unprocessed faces without
+ * re-clustering everything — "All" can overwrite manual corrections).
+ * Returns the job snapshot so the UI can show queue depth.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+    await runFacialRecognitionMissing(gate.user);
+    const status = await getJobStatus(gate.user);
+    return res.status(200).json({
+      queuedAt: new Date().toISOString(),
+      facialRecognition: status?.facialRecognition ?? {},
+    });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/types/faceReview.ts
+++ b/src/types/faceReview.ts
@@ -1,0 +1,64 @@
+export interface IFaceReviewFace {
+  faceId: string;
+  assetId: string;
+  /** Cosine distance to the person's centroid embedding. Higher = less
+   * typical for this person = more likely misassigned. Null when the face
+   * has no embedding row. */
+  distance: number | null;
+  /** ISO date (yyyy-mm-dd) the photo was taken, camera-local when known. */
+  takenAt: string | null;
+  boundingBoxX1: number;
+  boundingBoxY1: number;
+  boundingBoxX2: number;
+  boundingBoxY2: number;
+  imageWidth: number;
+  imageHeight: number;
+  /** Only on candidate faces: the person the face is currently assigned to. */
+  curPersonId?: string | null;
+  curName?: string | null;
+}
+
+export interface IFaceCluster {
+  /** 1-based display index, assigned after sorting. */
+  index: number;
+  size: number;
+  /** Mean distance-to-centroid of the cluster's faces (candidate clusters
+   * are sorted by this ascending — most-likely-the-person first). */
+  meanDistance: number | null;
+  faces: IFaceReviewFace[];
+}
+
+export interface IRankedFacesResponse {
+  faces: IFaceReviewFace[];
+  total: number;
+  page: number;
+  perPage: number;
+  personName: string;
+  birthDate: string | null;
+}
+
+export interface IClustersResponse {
+  clusters: IFaceCluster[];
+  singletonCount: number;
+  threshold: number;
+  totalFaces: number;
+}
+
+export interface ICandidatesResponse {
+  candidates: IFaceReviewFace[];
+  hasNext: boolean;
+}
+
+export interface ICandidateClustersResponse extends IClustersResponse {
+  poolSize: number;
+}
+
+export type IFaceReviewScope = "unnamed" | "named";
+
+export interface IFaceReviewPerson {
+  id: string;
+  name: string;
+  birthDate: string | null;
+  isHidden: boolean;
+  faceCount: number;
+}


### PR DESCRIPTION
**Part 3 of 4** of the Face Review tool. **Stacked on #310** (read layer,
which is itself on #309). Until those merge, the diff here includes them.
Review order: #309 → #310 → this → UI.

## What this adds

The **mutation API** for Face Review, all written with the requesting user's
own Immich session (cookie or API key) so Immich stays authoritative for
authorization — Power Tools never escalates:
- `immich.ts` (typed Immich calls) and `actions.ts` (reassign/merge helpers).
- Routes: reassign a face to another person; split a face to a new Stranger;
  hide a face as "not a face" (a reversible DB flag); reassign/stranger a
  whole person; clear empty people; start a facial-recognition scan; and poll
  job status.

## Notable, verified against Immich's own compiled service code
- A whole-person **merge** doesn't set a feature face on the target (unlike
  the per-face reassign endpoints, which self-heal a null `faceAssetId`), so
  `actions.ts` replicates that self-heal after every merge — otherwise a
  newly-named person ends up with no cover photo.
- `PUT /faces/{personId}` takes a body of `{ id: faceId }`; the reversed
  shape is intentional and documented in `immich.ts`.

## Testing
`tsc --noEmit` clean. Writes exercised and fully reversed on a throwaway
1-face Stranger (split → reassign-back → clear-empty; not-a-face hide →
restore; whole-person rename round-trip).
