### PR TITLE
feat(face-review): UI — pages, components, and nav (4/4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,14 @@ COPY --from=builder --chown=nextjs:nodejs /app/src/db/migrations ./src/db/migrat
 COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@libsql ./node_modules/@libsql
 COPY --from=deps --chown=nextjs:nodejs /app/node_modules/libsql ./node_modules/libsql
 
+# Same insurance for sharp (Face Review's face-crop endpoint): its platform
+# binaries live in @img/* optional deps that standalone tracing can miss.
+# sharp itself comes via Next's optionalDependencies, not package.json.
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/sharp ./node_modules/sharp
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@img ./node_modules/@img
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/detect-libc ./node_modules/detect-libc
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/semver ./node_modules/semver
+
 RUN mkdir -p /app/data && chown nextjs:nodejs /app/data
 
 USER nextjs

--- a/src/components/face-review/BulkBar.tsx
+++ b/src/components/face-review/BulkBar.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from "react";
+import { Loader2, X } from "lucide-react";
+import toast from "react-hot-toast";
+
+import PersonNameInput, { INameValue } from "@/components/face-review/PersonNameInput";
+import { Button } from "@/components/ui/button";
+import { reassignFaces, strangerFaces } from "@/handlers/api/faceReview.handler";
+
+/**
+ * The one write surface every review view shares: assign the selected faces
+ * a name (existing or new) or split them off as a single unknown person.
+ * Views pass what happens after a successful write via onDone; extraActions
+ * lets candidate-cluster detail add its client-only "No, not them".
+ */
+export default function BulkBar({
+  selectedIds,
+  defaultTarget,
+  onDone,
+  onCancel,
+  extraActions,
+  hint,
+}: {
+  selectedIds: string[];
+  /** Prefill (Find More cluster detail: confirming the person is one click). */
+  defaultTarget?: INameValue;
+  onDone: (removedFaceIds: string[], summary: string) => void;
+  onCancel?: () => void;
+  extraActions?: React.ReactNode;
+  hint?: string;
+}) {
+  const [target, setTarget] = useState<INameValue>(defaultTarget ?? { name: "" });
+  const [busy, setBusy] = useState<null | "assign" | "stranger">(null);
+
+  const run = async (kind: "assign" | "stranger", override?: INameValue) => {
+    if (busy || !selectedIds.length) return;
+    // A dropdown pick made this same keystroke (Enter) arrives via `override`
+    // — `target` state from it hasn't landed yet when this runs.
+    const t = override ?? target;
+    if (kind === "assign" && !t.personId && !t.name.trim()) {
+      toast.error("Type a name first");
+      return;
+    }
+    setBusy(kind);
+    try {
+      if (kind === "assign") {
+        const res = await reassignFaces({
+          faceIds: selectedIds,
+          ...(t.personId ? { personId: t.personId } : { name: t.name.trim() }),
+        });
+        onDone(
+          selectedIds,
+          `Reassigned ${res.done} face${res.done === 1 ? "" : "s"}` +
+            (res.failed ? `, ${res.failed} failed` : "")
+        );
+        setTarget({ name: "" });
+      } else {
+        const res = await strangerFaces(selectedIds);
+        onDone(
+          selectedIds,
+          `Split ${res.done} face${res.done === 1 ? "" : "s"} off as ${res.name}` +
+            (res.failed ? `, ${res.failed} failed` : "")
+        );
+      }
+    } catch (e: any) {
+      toast.error(`Failed: ${e?.error || e?.message || "unknown"}`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-lg border border-primary bg-card px-4 py-3">
+      <span className="text-sm font-semibold text-muted-foreground">
+        {selectedIds.length} selected
+      </span>
+      {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
+      <PersonNameInput value={target} onChange={setTarget} onSubmit={(v) => run("assign", v)} />
+      <Button size="sm" disabled={!!busy || !selectedIds.length} onClick={() => run("assign")}>
+        {busy === "assign" && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
+        Assign name
+      </Button>
+      <Button size="sm" variant="secondary" disabled={!!busy || !selectedIds.length} onClick={() => run("stranger")}>
+        {busy === "stranger" && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
+        Same unknown person
+      </Button>
+      {extraActions}
+      {onCancel && (
+        <Button size="sm" variant="ghost" className="ml-auto" onClick={onCancel} disabled={!!busy}>
+          <X className="mr-1 h-3 w-3" /> Cancel
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/face-review/ClusterViews.tsx
+++ b/src/components/face-review/ClusterViews.tsx
@@ -1,0 +1,310 @@
+import React, { useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, Loader2, ThumbsDown } from "lucide-react";
+import toast from "react-hot-toast";
+
+import BulkBar from "@/components/face-review/BulkBar";
+import FaceCard from "@/components/face-review/FaceCard";
+import FaceCrop from "@/components/face-review/FaceCrop";
+import Lightbox from "@/components/face-review/Lightbox";
+import { addRejects, loadRejects } from "@/components/face-review/rejectList";
+import ReviewTabs, { IReviewNavProps } from "@/components/face-review/ReviewTabs";
+import { useFaceSelection } from "@/components/face-review/useFaceSelection";
+import { Button } from "@/components/ui/button";
+import { getCandidateClusters, getPersonClusters } from "@/handlers/api/faceReview.handler";
+import { cn } from "@/lib/utils";
+import { IFaceCluster } from "@/types/faceReview";
+
+/** Mosaic card for one cluster: up to 6 sample crops + count. */
+function ClusterCard({ cluster, onOpen, subtitle }: { cluster: IFaceCluster; onOpen: () => void; subtitle?: string }) {
+  const samples = cluster.faces.slice(0, 6);
+  return (
+    <button
+      onClick={onOpen}
+      className="rounded-xl border bg-card p-3 text-left transition-colors hover:border-primary"
+    >
+      {/* Always 3 columns so every crop is the same size regardless of how
+          many faces the cluster has (a 2-face cluster used to render big
+          half-width crops; keep them at the 4-6-face size). */}
+      <div className="grid grid-cols-3 gap-1">
+        {samples.map((f) => (
+          <FaceCrop key={f.faceId} face={f} size={120} className="w-full aspect-square rounded-md bg-muted" />
+        ))}
+      </div>
+      <div className="mt-2 text-sm font-medium">
+        Cluster {cluster.index} · {cluster.size} faces
+      </div>
+      {subtitle && <div className="text-xs text-muted-foreground">{subtitle}</div>}
+    </button>
+  );
+}
+
+/**
+ * Open-cluster detail, wired to the shared BulkBar. Candidate clusters start
+ * PRE-SELECTED (confirming a found relative as a whole is one click); own-face
+ * clusters start with NOTHING selected (defaultSelectAll=false) — you're
+ * usually hunting a few strays inside your own faces, not confirming the lot.
+ */
+function ClusterDetail({
+  cluster,
+  onBack,
+  nav,
+  defaultSelectAll,
+  defaultTargetName,
+  defaultTargetId,
+  onRejectCluster,
+}: {
+  cluster: IFaceCluster;
+  onBack: () => void;
+  nav: IReviewNavProps;
+  defaultSelectAll: boolean;
+  defaultTargetName?: string;
+  defaultTargetId?: string;
+  onRejectCluster?: (faceIds: string[]) => void;
+}) {
+  const [removed, setRemoved] = useState<Set<string>>(new Set());
+  const [lightboxAsset, setLightboxAsset] = useState<string | null>(null);
+  const visible = useMemo(() => cluster.faces.filter((f) => !removed.has(f.faceId)), [cluster, removed]);
+  const orderedIds = useMemo(() => visible.map((f) => f.faceId), [visible]);
+  const selection = useFaceSelection(orderedIds);
+  const { selectMany, clear } = selection;
+  React.useEffect(() => {
+    if (defaultSelectAll) selectMany(cluster.faces.map((f) => f.faceId));
+    else clear();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cluster.index]);
+
+  const afterWrite = (faceIds: string[], summary: string) => {
+    toast.success(summary);
+    const next = new Set(removed);
+    faceIds.forEach((id) => next.add(id));
+    setRemoved(next);
+    selection.clear();
+    if (next.size >= cluster.faces.length) onBack(); // cluster emptied
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Back + Select all/none live on the tab row (#9d/#9e); the selected
+          count now shows only once, in the BulkBar (#9a), and the cluster
+          number is gone (#9b). */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Button size="sm" variant="ghost" onClick={onBack}>
+          <ArrowLeft size={14} className="mr-1" /> Back to clusters
+        </Button>
+        <ReviewTabs tab={nav.tab} sub={nav.sub} scope={nav.scope} setParams={nav.setParams} showInclude={false} />
+        <div className="ml-auto flex items-center gap-2">
+          <Button size="sm" variant="outline" onClick={selection.selectAll}>Select all</Button>
+          <Button size="sm" variant="outline" onClick={selection.clear}>Deselect all</Button>
+        </div>
+      </div>
+      <BulkBar
+        selectedIds={[...selection.selected]}
+        defaultTarget={defaultTargetName ? { personId: defaultTargetId, name: defaultTargetName } : undefined}
+        onDone={afterWrite}
+        onCancel={onBack}
+        extraActions={
+          onRejectCluster && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={!selection.selected.size}
+              title="Not this person — hide these candidates on this device (writes nothing to Immich)"
+              onClick={() => {
+                const ids = [...selection.selected];
+                onRejectCluster(ids);
+                afterWrite(ids, `Skipped ${ids.length} on this device`);
+              }}
+            >
+              <ThumbsDown size={14} className="mr-1" /> No, not them
+            </Button>
+          )
+        }
+      />
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(190px,1fr))] gap-4">
+        {visible.map((face) => (
+          <FaceCard
+            key={face.faceId}
+            face={face}
+            selected={selection.selected.has(face.faceId)}
+            className={cn(!selection.selected.has(face.faceId) && "border-red-500/50")}
+            onCropClick={() => setLightboxAsset(face.assetId)}
+          >
+            <div className="mt-2">
+              <Button
+                size="sm"
+                variant={selection.selected.has(face.faceId) ? "default" : "outline"}
+                className="w-full h-7 text-xs"
+                onClick={(e) => selection.toggle(face.faceId, e.shiftKey)}
+              >
+                {selection.selected.has(face.faceId) ? "✓ Selected" : "Select"}
+              </Button>
+            </div>
+          </FaceCard>
+        ))}
+      </div>
+      <Lightbox assetId={lightboxAsset} onClose={() => setLightboxAsset(null)} />
+    </div>
+  );
+}
+
+/** "Tagged > Clusters": the person's own faces grouped by similarity. */
+export function OwnClustersView({ personId, ...nav }: { personId: string } & IReviewNavProps) {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState<IFaceCluster | null>(null);
+  const query = useQuery({
+    queryKey: ["face-review", "clusters", personId],
+    queryFn: () => getPersonClusters(personId),
+  });
+
+  if (query.isLoading) return <ClustersLoading label="Grouping faces…" />;
+  if (query.isError) return <div className="py-12 text-center text-destructive">Failed: {String((query.error as any)?.error || (query.error as any)?.message)}</div>;
+  const { clusters = [], singletonCount = 0 } = query.data ?? {};
+
+  if (open) {
+    return (
+      <ClusterDetail
+        cluster={open}
+        nav={nav}
+        defaultSelectAll={false}
+        onBack={() => {
+          setOpen(null);
+          queryClient.invalidateQueries({ queryKey: ["face-review", "clusters", personId] });
+          queryClient.invalidateQueries({ queryKey: ["face-review", "faces", personId] });
+        }}
+      />
+    );
+  }
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <ReviewTabs {...nav} />
+        <span className="ml-auto text-sm text-muted-foreground">
+          {clusters.length} cluster{clusters.length === 1 ? "" : "s"}
+          {singletonCount ? ` · ${singletonCount} unclustered face${singletonCount === 1 ? "" : "s"}` : ""}
+        </span>
+      </div>
+      <div className="text-sm text-muted-foreground">
+        A tight sub-group that isn&apos;t this person is a wrongly-merged someone else.
+      </div>
+      {!clusters.length ? (
+        <div className="py-12 text-center text-muted-foreground">
+          {singletonCount
+            ? `No sub-clusters of 2+ faces — all ${singletonCount} faces are singletons. Check Tagged Faces instead.`
+            : "Not enough faces to cluster."}
+        </div>
+      ) : (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-4">
+          {clusters.map((c) => (
+            <ClusterCard key={c.index} cluster={c} onOpen={() => setOpen(c)} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * "Find more > Clusters": the CANDIDATE pool clustered by mutual similarity
+ * — a missed relative shows as one group instead of dozens of Yes/No cards.
+ * Threshold is adjustable here (unlike own-face clusters); the bulk-name box
+ * arrives prefilled so confirming a whole cluster is one click; "No, not
+ * them" feeds the same per-device reject list as the Faces sub-tab.
+ */
+export function CandidateClustersView({
+  personId,
+  personName,
+  ...nav
+}: {
+  personId: string;
+  personName: string;
+} & IReviewNavProps) {
+  const { scope } = nav;
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState<IFaceCluster | null>(null);
+  const [threshold, setThreshold] = useState(0.65);
+  const [appliedThreshold, setAppliedThreshold] = useState(0.65);
+  const [rejectVersion, setRejectVersion] = useState(0);
+
+  const query = useQuery({
+    queryKey: ["face-review", "candidate-clusters", personId, scope, appliedThreshold, rejectVersion],
+    queryFn: () =>
+      getCandidateClusters(personId, {
+        scope,
+        threshold: appliedThreshold,
+        exclude: [...loadRejects(personId)],
+      }),
+  });
+
+  if (query.isLoading) return <ClustersLoading label="Grouping candidates…" />;
+  if (query.isError) return <div className="py-12 text-center text-destructive">Failed: {String((query.error as any)?.error || (query.error as any)?.message)}</div>;
+  const { clusters = [], singletonCount = 0, poolSize = 0 } = query.data ?? {};
+
+  if (open) {
+    return (
+      <ClusterDetail
+        cluster={open}
+        nav={nav}
+        defaultSelectAll={true}
+        defaultTargetName={personName}
+        defaultTargetId={personId}
+        onRejectCluster={(ids) => {
+          addRejects(personId, ids);
+        }}
+        onBack={() => {
+          setOpen(null);
+          setRejectVersion((v) => v + 1);
+          queryClient.invalidateQueries({ queryKey: ["face-review", "candidate-clusters", personId] });
+          queryClient.invalidateQueries({ queryKey: ["face-review", "candidates", personId] });
+        }}
+      />
+    );
+  }
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <ReviewTabs {...nav} />
+        <label className="text-sm text-muted-foreground" title="How similar two faces must look to land in the same group">
+          Similarity {threshold.toFixed(2)}
+        </label>
+        <span className="text-[11px] text-muted-foreground">← Looser</span>
+        <input
+          type="range" min={0.45} max={0.85} step={0.01} value={threshold}
+          className="w-36 accent-primary"
+          onChange={(e) => setThreshold(+e.target.value)}
+          onMouseUp={() => setAppliedThreshold(threshold)}
+          onTouchEnd={() => setAppliedThreshold(threshold)}
+        />
+        <span className="text-[11px] text-muted-foreground">Stricter →</span>
+        <span className="ml-auto text-sm text-muted-foreground">
+          {clusters.length} cluster{clusters.length === 1 ? "" : "s"} in the closest {poolSize} candidates
+          {singletonCount ? ` · ${singletonCount} singletons` : ""}
+        </span>
+      </div>
+      {!clusters.length ? (
+        <div className="py-12 text-center text-muted-foreground">
+          No candidate clusters at this similarity level.
+        </div>
+      ) : (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-4">
+          {clusters.map((c) => (
+            <ClusterCard
+              key={c.index}
+              cluster={c}
+              onOpen={() => setOpen(c)}
+              subtitle={c.meanDistance !== null ? `mean distance ${c.meanDistance}` : undefined}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ClustersLoading({ label }: { label: string }) {
+  return (
+    <div className="flex items-center justify-center gap-2 py-16 text-muted-foreground">
+      <Loader2 className="animate-spin" size={18} /> {label}
+    </div>
+  );
+}

--- a/src/components/face-review/FaceCard.tsx
+++ b/src/components/face-review/FaceCard.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { Check } from "lucide-react";
+
+import FaceCrop from "@/components/face-review/FaceCrop";
+import { cn } from "@/lib/utils";
+import { IFaceReviewFace } from "@/types/faceReview";
+
+/** Distance pill color bands, same cut points as the source tool. */
+const distClass = (d: number) =>
+  d >= 0.5 ? "bg-red-500/80" : d >= 0.3 ? "bg-amber-500/80" : "bg-emerald-600/80";
+
+/**
+ * One face in a review grid: square crop + distance pill + optional
+ * "now: <name>" badge + capture date, with a selection checkmark overlay.
+ * Action buttons come in via children so each tab composes its own.
+ */
+export default function FaceCard({
+  face,
+  selected,
+  verdict,
+  onCropClick,
+  children,
+  className,
+}: {
+  face: IFaceReviewFace;
+  selected?: boolean;
+  /** Find More staging state — colors the border. */
+  verdict?: "yes" | "no" | null;
+  onCropClick?: (e: React.MouseEvent) => void;
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "relative rounded-xl border bg-card p-3 transition-colors",
+        selected && "border-primary ring-2 ring-primary",
+        verdict === "yes" && "border-emerald-500 ring-2 ring-emerald-500",
+        verdict === "no" && "border-red-500 ring-2 ring-red-500",
+        className
+      )}
+    >
+      {selected && (
+        <span className="absolute top-4 right-4 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground shadow">
+          <Check size={14} />
+        </span>
+      )}
+      {face.distance !== null && (
+        <span
+          className={cn(
+            "absolute top-4 left-4 z-10 rounded px-1.5 py-0.5 text-[11px] font-semibold text-white",
+            distClass(face.distance)
+          )}
+          title="Cosine distance from this person's average face — higher = less typical"
+        >
+          {face.distance}
+        </span>
+      )}
+      {face.curName && (
+        <span
+          className="absolute top-4 right-4 z-10 rounded bg-black/65 px-1.5 py-0.5 text-[11px] text-white"
+          title={`Currently assigned to ${face.curName}`}
+        >
+          now: {face.curName}
+        </span>
+      )}
+      <FaceCrop
+        face={face}
+        className="w-full aspect-square rounded-lg bg-muted cursor-pointer"
+        onClick={onCropClick}
+      />
+      {face.takenAt && (
+        <div className="mt-1 text-center text-xs text-muted-foreground">{face.takenAt}</div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/components/face-review/FaceCrop.tsx
+++ b/src/components/face-review/FaceCrop.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+import { IFaceReviewFace } from "@/types/faceReview";
+
+/**
+ * Square face crop. The cropping itself happens server-side
+ * (/api/face-review/faces/[faceId]/crop) — the server sits next to Immich,
+ * pulls the big preview over LAN, and ships only a small WebP of the face.
+ * The old version downloaded the full preview to the browser and cropped it
+ * on a canvas, which made remote sessions crawl.
+ *
+ * Plain <img> so we get native lazy loading: below-the-fold crops don't
+ * fetch until scrolled near. The response is immutable-cached, so revisits
+ * render from the browser cache.
+ */
+export default function FaceCrop({
+  face,
+  size = 200,
+  className,
+  onClick,
+  title,
+}: {
+  face: IFaceReviewFace;
+  size?: number;
+  className?: string;
+  onClick?: (e: React.MouseEvent) => void;
+  title?: string;
+}) {
+  // Request 2x the display size for hi-dpi screens; endpoint allows 400/800.
+  const fetchSize = size > 200 ? 800 : 400;
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={`/api/face-review/faces/${face.faceId}/crop?s=${fetchSize}`}
+      alt=""
+      width={size}
+      height={size}
+      loading="lazy"
+      decoding="async"
+      onClick={onClick}
+      title={title}
+      className={className}
+    />
+  );
+}

--- a/src/components/face-review/FindMoreFacesView.tsx
+++ b/src/components/face-review/FindMoreFacesView.tsx
@@ -1,0 +1,194 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2, ThumbsDown } from "lucide-react";
+import toast from "react-hot-toast";
+
+import BulkBar from "@/components/face-review/BulkBar";
+import FaceCard from "@/components/face-review/FaceCard";
+import Lightbox from "@/components/face-review/Lightbox";
+import { addRejects, clearRejects, loadRejects } from "@/components/face-review/rejectList";
+import ReviewTabs, { IReviewNavProps } from "@/components/face-review/ReviewTabs";
+import { useFaceSelection } from "@/components/face-review/useFaceSelection";
+import { Button } from "@/components/ui/button";
+import { getCandidates } from "@/handlers/api/faceReview.handler";
+import { IFaceReviewFace } from "@/types/faceReview";
+
+const BATCH = 24;
+
+/**
+ * "Find more > Faces": multi-select review of look-alike candidates,
+ * closest-first — the same select/BulkBar surface as the cluster and Tagged
+ * views (was per-card Yes/No). Select the crops that ARE this person and
+ * "Assign name" (prefilled with them = one-click confirm), or split a group
+ * off as a stranger. "No, not them" hides the selection on this device via
+ * the per-device reject list — deliberately never written to Immich.
+ */
+export default function FindMoreFacesView({
+  personId,
+  personName,
+  ...nav
+}: {
+  personId: string;
+  personName: string;
+} & IReviewNavProps) {
+  const { scope } = nav;
+  const [cards, setCards] = useState<IFaceReviewFace[]>([]);
+  const [hasNext, setHasNext] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [skipCount, setSkipCount] = useState(0);
+  const [lightboxAsset, setLightboxAsset] = useState<string | null>(null);
+
+  const orderedIds = useMemo(() => cards.map((c) => c.faceId), [cards]);
+  const selection = useFaceSelection(orderedIds);
+
+  const refreshSkipCount = useCallback(() => setSkipCount(loadRejects(personId).size), [personId]);
+
+  const load = useCallback(
+    async (reset: boolean) => {
+      setLoading(true);
+      try {
+        const res = await getCandidates(personId, {
+          scope,
+          exclude: [...loadRejects(personId)],
+          limit: BATCH,
+          offset: reset ? 0 : cards.length,
+        });
+        setCards((prev) => (reset ? res.candidates : [...prev, ...res.candidates]));
+        setHasNext(res.hasNext);
+      } catch (e: any) {
+        toast.error(`Failed: ${e?.error || e?.message || "unknown"}`);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [personId, scope, cards.length]
+  );
+
+  useEffect(() => {
+    setCards([]);
+    selection.clear();
+    refreshSkipCount();
+    load(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [personId, scope]);
+
+  /** Drop faces from the visible grid once they've been actioned. */
+  const removeCards = (faceIds: string[]) => {
+    const gone = new Set(faceIds);
+    setCards((prev) => prev.filter((c) => !gone.has(c.faceId)));
+    selection.clear();
+  };
+
+  const afterWrite = (faceIds: string[], summary: string) => {
+    toast.success(summary);
+    removeCards(faceIds);
+  };
+
+  const rejectSelected = () => {
+    const ids = [...selection.selected];
+    if (!ids.length) return;
+    addRejects(personId, ids); // per-device only — writes nothing to Immich
+    removeCards(ids);
+    refreshSkipCount();
+    toast.success(`Skipped ${ids.length} on this device`);
+  };
+
+  const emptyText = useMemo(
+    () =>
+      scope === "named"
+        ? "No already-named look-alike faces left."
+        : 'No unnamed look-alike faces left. Try "Already-named faces" above.',
+    [scope]
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* tab bar (incl. the Include selector) + Select all/none on one row */}
+      <div className="flex flex-wrap items-center gap-3">
+        <ReviewTabs {...nav} />
+        <div className="ml-auto flex items-center gap-2">
+          <Button size="sm" variant="outline" onClick={selection.selectAll} disabled={!cards.length}>Select all</Button>
+          <Button size="sm" variant="outline" onClick={selection.clear} disabled={!selection.selected.size}>Deselect all</Button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+        <span>
+          Select the faces that are {personName || "this person"}, then Assign. &quot;No, not
+          them&quot; hides the selection on this device (nothing is written to Immich).
+        </span>
+        {skipCount > 0 && (
+          <span className="ml-auto">
+            {skipCount} face{skipCount === 1 ? "" : "s"} skipped on this device ·{" "}
+            <button
+              className="underline hover:text-foreground"
+              onClick={() => {
+                if (!confirm('Forget the faces you marked "No" for this person on this device? They can then reappear as candidates.')) return;
+                clearRejects(personId);
+                refreshSkipCount();
+                load(true);
+              }}
+            >
+              reset
+            </button>
+          </span>
+        )}
+      </div>
+
+      {selection.selected.size > 0 && (
+        <div className="sticky top-0 z-20">
+          <BulkBar
+            selectedIds={[...selection.selected]}
+            defaultTarget={{ personId, name: personName }}
+            onDone={afterWrite}
+            onCancel={selection.clear}
+            extraActions={
+              <Button
+                size="sm"
+                variant="outline"
+                title="Not this person — hide these candidates on this device (writes nothing to Immich)"
+                onClick={rejectSelected}
+              >
+                <ThumbsDown size={14} className="mr-1" /> No, not them
+              </Button>
+            }
+          />
+        </div>
+      )}
+
+      {!cards.length && !loading ? (
+        <div className="py-16 text-center text-muted-foreground">{emptyText}</div>
+      ) : (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(190px,1fr))] gap-4">
+          {cards.map((face) => (
+            <FaceCard
+              key={face.faceId}
+              face={face}
+              selected={selection.selected.has(face.faceId)}
+              onCropClick={() => setLightboxAsset(face.assetId)}
+            >
+              <div className="mt-2">
+                <Button
+                  size="sm"
+                  variant={selection.selected.has(face.faceId) ? "default" : "outline"}
+                  className="w-full h-7 text-xs"
+                  onClick={(e) => selection.toggle(face.faceId, e.shiftKey)}
+                >
+                  {selection.selected.has(face.faceId) ? "✓ Selected" : "Select"}
+                </Button>
+              </div>
+            </FaceCard>
+          ))}
+        </div>
+      )}
+
+      <div className="flex justify-center">
+        {loading ? (
+          <Loader2 className="animate-spin text-muted-foreground" />
+        ) : hasNext ? (
+          <Button variant="ghost" onClick={() => load(false)}>Load more</Button>
+        ) : null}
+      </div>
+      <Lightbox assetId={lightboxAsset} onClose={() => setLightboxAsset(null)} />
+    </div>
+  );
+}

--- a/src/components/face-review/Lightbox.tsx
+++ b/src/components/face-review/Lightbox.tsx
@@ -1,0 +1,45 @@
+import React, { useContext } from "react";
+import { ExternalLink } from "lucide-react";
+
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import ConfigContext from "@/contexts/ConfigContext";
+
+/**
+ * Full-photo preview for a face card — reuses the asset thumbnail proxy
+ * (preview size, browser-cached) so eyeballing a photo never needs a new
+ * tab or an Immich login.
+ */
+export default function Lightbox({
+  assetId,
+  onClose,
+}: {
+  assetId: string | null;
+  onClose: () => void;
+}) {
+  const { exImmichUrl } = useContext(ConfigContext);
+  return (
+    <Dialog open={!!assetId} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-4xl p-2">
+        <DialogTitle className="sr-only">Photo preview</DialogTitle>
+        {assetId && (
+          <div className="flex flex-col gap-2 items-center">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`/api/immich-proxy/asset/thumbnail/${assetId}?size=preview`}
+              alt="Photo preview"
+              className="max-h-[80vh] rounded-md object-contain"
+            />
+            <a
+              href={`${exImmichUrl}/photos/${assetId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+            >
+              Open in Immich <ExternalLink size={14} />
+            </a>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/face-review/Pager.tsx
+++ b/src/components/face-review/Pager.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+import { Button } from "@/components/ui/button";
+
+/** Numbered pager: 1 … window around current … last. */
+export default function Pager({
+  page,
+  totalPages,
+  onPage,
+}: {
+  page: number;
+  totalPages: number;
+  onPage: (p: number) => void;
+}) {
+  if (totalPages <= 1) return null;
+  const pages: (number | "…")[] = [];
+  const push = (p: number | "…") => pages[pages.length - 1] !== p && pages.push(p);
+  for (let p = 1; p <= totalPages; p++) {
+    if (p === 1 || p === totalPages || Math.abs(p - page) <= 2) push(p);
+    else push("…");
+  }
+  return (
+    <div className="flex items-center justify-center gap-1 flex-wrap">
+      {pages.map((p, i) =>
+        p === "…" ? (
+          <span key={`e${i}`} className="px-1 text-muted-foreground">…</span>
+        ) : (
+          <Button
+            key={p}
+            size="sm"
+            variant={p === page ? "default" : "ghost"}
+            onClick={() => onPage(p)}
+          >
+            {p}
+          </Button>
+        )
+      )}
+    </div>
+  );
+}

--- a/src/components/face-review/PersonNameInput.tsx
+++ b/src/components/face-review/PersonNameInput.tsx
@@ -1,0 +1,118 @@
+import React, { useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { Input } from "@/components/ui/input";
+import { getNames } from "@/handlers/api/faceReview.handler";
+import { cn } from "@/lib/utils";
+
+export interface INameValue {
+  /** Set when an existing person was picked from the list. */
+  personId?: string;
+  name: string;
+}
+
+/**
+ * Free-typed name input with autocomplete over the owner's named people and
+ * a "create new person" affordance. Typing after a pick invalidates the
+ * picked id (otherwise a stale id would silently win over the visible text).
+ */
+export default function PersonNameInput({
+  value,
+  onChange,
+  onSubmit,
+  placeholder = "This is actually…",
+  className,
+}: {
+  value: INameValue;
+  onChange: (v: INameValue) => void;
+  /** Receives the value actually being submitted — a dropdown pick made this
+   * same keystroke hasn't reached the caller's state yet, so callers must
+   * use this argument rather than re-reading their own (stale) state. */
+  onSubmit?: (submitted: INameValue) => void;
+  placeholder?: string;
+  className?: string;
+}) {
+  const { data: names = [] } = useQuery({ queryKey: ["face-review", "names"], queryFn: getNames });
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const blurTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const q = value.name.trim().toLowerCase();
+  const matches = useMemo(
+    () => (q ? names.filter((n) => n.name.toLowerCase().includes(q)).slice(0, 8) : []),
+    [names, q]
+  );
+  const exactExists = names.some((n) => n.name.toLowerCase() === q);
+  const rows: { id?: string; name: string; create?: boolean }[] = useMemo(() => {
+    const r: { id?: string; name: string; create?: boolean }[] = [...matches];
+    if (q && !exactExists) r.push({ name: value.name.trim(), create: true });
+    return r;
+  }, [matches, q, exactExists, value.name]);
+
+  const pick = (row: { id?: string; name: string }) => {
+    onChange({ personId: row.id, name: row.name });
+    setOpen(false);
+  };
+
+  return (
+    <div className={cn("relative min-w-[220px]", className)}>
+      <Input
+        value={value.name}
+        placeholder={placeholder}
+        onChange={(e) => {
+          onChange({ name: e.target.value }); // typing drops any picked id
+          setOpen(true);
+          setActiveIdx(0);
+        }}
+        onFocus={() => value.name && setOpen(true)}
+        onBlur={() => {
+          // Delay so a mousedown on a suggestion row lands first.
+          blurTimer.current = setTimeout(() => setOpen(false), 150);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setActiveIdx((i) => Math.min(rows.length - 1, i + 1));
+          } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setActiveIdx((i) => Math.max(0, i - 1));
+          } else if (e.key === "Enter") {
+            e.preventDefault();
+            if (open && rows[activeIdx]) {
+              const row = rows[activeIdx];
+              const picked: INameValue = { personId: row.id, name: row.name };
+              onChange(picked);
+              setOpen(false);
+              onSubmit?.(picked);
+            } else {
+              onSubmit?.(value);
+            }
+          } else if (e.key === "Escape") {
+            setOpen(false);
+          }
+        }}
+      />
+      {open && rows.length > 0 && (
+        <div className="absolute z-50 mt-1 w-full rounded-md border bg-popover text-popover-foreground shadow-md max-h-64 overflow-y-auto">
+          {rows.map((row, i) => (
+            <div
+              key={row.id ?? `__create_${row.name}`}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                clearTimeout(blurTimer.current);
+                pick(row);
+              }}
+              className={cn(
+                "px-3 py-1.5 text-sm cursor-pointer",
+                i === activeIdx ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
+                row.create && "italic"
+              )}
+            >
+              {row.create ? <>➕ Create new person “{row.name}”</> : row.name}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/face-review/ReviewTabs.tsx
+++ b/src/components/face-review/ReviewTabs.tsx
@@ -57,7 +57,7 @@ export default function ReviewTabs({
         <div className="flex items-center gap-2">
           <label className="text-sm text-muted-foreground">Include</label>
           <Select value={scope} onValueChange={(v) => setParams({ scope: v })}>
-            <SelectTrigger className="w-48 h-8"><SelectValue /></SelectTrigger>
+            <SelectTrigger className="w-48 h-9"><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectItem value="unnamed">Unnamed faces only</SelectItem>
               <SelectItem value="named">Already-named faces</SelectItem>

--- a/src/components/face-review/ReviewTabs.tsx
+++ b/src/components/face-review/ReviewTabs.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { IFaceReviewScope } from "@/types/faceReview";
+
+export type IPrimaryTab = "tagged" | "find-more";
+export type ISubTab = "faces" | "clusters";
+
+/** Tab-bar wiring every review view threads through to <ReviewTabs/>. */
+export interface IReviewNavProps {
+  tab: IPrimaryTab;
+  sub: ISubTab;
+  scope: IFaceReviewScope;
+  setParams: (params: Record<string, string>) => void;
+}
+
+/**
+ * The Face Review tab bar, rendered as bare flex children (a fragment) so each
+ * view can drop it into the SAME flex-wrap row as its own controls — the whole
+ * header (primary tab + sub-tab + view controls) then lives on one line
+ * instead of stacking. "Include" only makes sense while browsing Find More, so
+ * it hides inside an open cluster (showInclude=false).
+ */
+export default function ReviewTabs({
+  tab,
+  sub,
+  scope,
+  setParams,
+  showInclude = tab === "find-more",
+}: {
+  tab: IPrimaryTab;
+  sub: ISubTab;
+  scope: IFaceReviewScope;
+  setParams: (params: Record<string, string>) => void;
+  showInclude?: boolean;
+}) {
+  return (
+    <>
+      <Tabs value={tab} onValueChange={(v) => setParams({ tab: v, sub: "faces" })}>
+        <TabsList>
+          {/* "Tagged" (not "Tagged faces") — the section covers both the Faces
+              and Clusters sub-tabs, so "faces" here was misleading. */}
+          <TabsTrigger value="tagged">Tagged</TabsTrigger>
+          <TabsTrigger value="find-more">Find more</TabsTrigger>
+        </TabsList>
+      </Tabs>
+      <Tabs value={sub} onValueChange={(v) => setParams({ sub: v })}>
+        <TabsList>
+          <TabsTrigger value="faces">Faces</TabsTrigger>
+          <TabsTrigger value="clusters">Clusters</TabsTrigger>
+        </TabsList>
+      </Tabs>
+      {showInclude && (
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-muted-foreground">Include</label>
+          <Select value={scope} onValueChange={(v) => setParams({ scope: v })}>
+            <SelectTrigger className="w-48 h-8"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="unnamed">Unnamed faces only</SelectItem>
+              <SelectItem value="named">Already-named faces</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/face-review/TaggedFacesView.tsx
+++ b/src/components/face-review/TaggedFacesView.tsx
@@ -179,7 +179,7 @@ export default function TaggedFacesView({
           <>
             <label className="text-sm text-muted-foreground">Show</label>
             <Select value={show} onValueChange={(v) => { setShow(v as any); setPage(1); setRemoved(new Set()); }}>
-              <SelectTrigger className="w-40 h-8"><SelectValue /></SelectTrigger>
+              <SelectTrigger className="w-40 h-9"><SelectValue /></SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All faces</SelectItem>
                 <SelectItem value="prebirth">Before birth date</SelectItem>
@@ -189,7 +189,7 @@ export default function TaggedFacesView({
               <>
                 <label className="text-sm text-muted-foreground">Sort</label>
                 <Select value={sort} onValueChange={(v) => { setSort(v as ISort); setPage(1); setRemoved(new Set()); }}>
-                  <SelectTrigger className="w-44 h-8"><SelectValue /></SelectTrigger>
+                  <SelectTrigger className="w-44 h-9"><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="confidence">Least typical first</SelectItem>
                     <SelectItem value="recent">Newest</SelectItem>
@@ -200,7 +200,7 @@ export default function TaggedFacesView({
             )}
             <label className="text-sm text-muted-foreground">Per page</label>
             <Select value={String(perPage)} onValueChange={(v) => { setPerPage(+v); setPage(1); setRemoved(new Set()); }}>
-              <SelectTrigger className="w-20 h-8"><SelectValue /></SelectTrigger>
+              <SelectTrigger className="w-20 h-9"><SelectValue /></SelectTrigger>
               <SelectContent>
                 {[25, 50, 100, 200].map((n) => (
                   <SelectItem key={n} value={String(n)}>{n}</SelectItem>

--- a/src/components/face-review/TaggedFacesView.tsx
+++ b/src/components/face-review/TaggedFacesView.tsx
@@ -1,0 +1,326 @@
+import React, { useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, Loader2 } from "lucide-react";
+import toast from "react-hot-toast";
+
+import BulkBar from "@/components/face-review/BulkBar";
+import FaceCard from "@/components/face-review/FaceCard";
+import Lightbox from "@/components/face-review/Lightbox";
+import Pager from "@/components/face-review/Pager";
+import PersonNameInput, { INameValue } from "@/components/face-review/PersonNameInput";
+import ReviewTabs, { IReviewNavProps } from "@/components/face-review/ReviewTabs";
+import { useFaceSelection } from "@/components/face-review/useFaceSelection";
+import { Button } from "@/components/ui/button";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import {
+  getRankedFaces, notAFace, reassignAll, reassignFaces, strangerAll, strangerFaces,
+} from "@/handlers/api/faceReview.handler";
+import { IFaceReviewFace } from "@/types/faceReview";
+
+type ISort = "confidence" | "recent" | "oldest";
+
+/**
+ * "Tagged > Faces": the person's own faces, least-typical-first. By default
+ * each card offers a single-face "Not <person>" correction. A top-level
+ * "Select" button flips the whole grid into multi-select mode — cards become
+ * togglable and the shared BulkBar drives bulk reassign/stranger — instead of
+ * a Select button under every crop.
+ */
+export default function TaggedFacesView({
+  personId,
+  personName,
+  tab,
+  sub,
+  scope,
+  setParams,
+  returnFilter,
+}: { personId: string; personName: string; returnFilter?: string } & IReviewNavProps) {
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(50);
+  const [sort, setSort] = useState<ISort>("confidence");
+  const [show, setShow] = useState<"all" | "prebirth">("all");
+  const [selectMode, setSelectMode] = useState(false);
+  const [lightboxAsset, setLightboxAsset] = useState<string | null>(null);
+  const [openMenuFace, setOpenMenuFace] = useState<string | null>(null);
+  const [menuTarget, setMenuTarget] = useState<INameValue>({ name: "" });
+  const [menuBusy, setMenuBusy] = useState(false);
+  const [globalOpen, setGlobalOpen] = useState(false);
+  const [globalTarget, setGlobalTarget] = useState<INameValue>({ name: "" });
+  const [globalBusy, setGlobalBusy] = useState(false);
+  // Locally-removed faces (post-action) so cards disappear without refetch.
+  const [removed, setRemoved] = useState<Set<string>>(new Set());
+
+  const query = useQuery({
+    queryKey: ["face-review", "faces", personId, page, perPage, sort, show],
+    queryFn: () => getRankedFaces(personId, { page, perPage, sort, show }),
+  });
+
+  const visibleFaces = useMemo(
+    () => (query.data?.faces ?? []).filter((f) => !removed.has(f.faceId)),
+    [query.data, removed]
+  );
+  const orderedIds = useMemo(() => visibleFaces.map((f) => f.faceId), [visibleFaces]);
+  const selection = useFaceSelection(orderedIds);
+
+  const exitSelectMode = () => {
+    selection.clear();
+    setSelectMode(false);
+  };
+
+  const refetchPage = () => {
+    setRemoved(new Set());
+    selection.clear();
+    queryClient.invalidateQueries({ queryKey: ["face-review", "faces", personId] });
+    queryClient.invalidateQueries({ queryKey: ["face-review", "clusters", personId] });
+  };
+
+  const afterWrite = (faceIds: string[], summary: string) => {
+    toast.success(summary);
+    const next = new Set(removed);
+    faceIds.forEach((id) => next.add(id));
+    setRemoved(next);
+    selection.clear();
+    setOpenMenuFace(null);
+    // Page emptied -> re-pull; the server clamps past-the-end page numbers,
+    // so this lands on the next page of faces (or the all-done state).
+    if (next.size >= (query.data?.faces.length ?? 0)) refetchPage();
+  };
+
+  const singleAction = async (face: IFaceReviewFace, kind: "assign" | "stranger" | "hide", override?: INameValue) => {
+    if (menuBusy) return;
+    // A dropdown pick made this same keystroke (Enter) arrives via `override`
+    // — `menuTarget` state from it hasn't landed yet when this runs.
+    const t = override ?? menuTarget;
+    if (kind === "assign" && !t.personId && !t.name.trim()) {
+      toast.error("Type a name first");
+      return;
+    }
+    setMenuBusy(true);
+    try {
+      if (kind === "assign") {
+        await reassignFaces({
+          faceIds: [face.faceId],
+          ...(t.personId ? { personId: t.personId } : { name: t.name.trim() }),
+        });
+        afterWrite([face.faceId], "Reassigned");
+        setMenuTarget({ name: "" });
+      } else if (kind === "stranger") {
+        const res = await strangerFaces([face.faceId]);
+        afterWrite([face.faceId], `Split off as ${res.name}`);
+      } else {
+        await notAFace(face.faceId);
+        afterWrite([face.faceId], "Hidden – not a face");
+      }
+    } catch (e: any) {
+      toast.error(`Failed: ${e?.error || e?.message || "unknown"}`);
+    } finally {
+      setMenuBusy(false);
+    }
+  };
+
+  const wholePerson = async (kind: "reassign" | "stranger", override?: INameValue) => {
+    if (globalBusy) return;
+    // A dropdown pick made this same keystroke (Enter) arrives via `override`
+    // — `globalTarget` state from it hasn't landed yet when this runs.
+    const t = override ?? globalTarget;
+    if (kind === "reassign" && !t.personId && !t.name.trim()) {
+      toast.error("Type a name first");
+      return;
+    }
+    if (kind === "stranger" && !confirm('Rename this whole person to a unique "Stranger" label?')) return;
+    setGlobalBusy(true);
+    try {
+      if (kind === "reassign") {
+        const body = t.personId
+          ? { personId: t.personId }
+          : { name: t.name.trim() };
+        try {
+          await reassignAll(personId, body);
+        } catch (e: any) {
+          if (e?.status === 409 || e?.needsConfirm || /Merge/.test(e?.message || "")) {
+            if (!confirm(`${e?.message || "Target already exists."}\n\nThis will merge this person into the existing one.`)) return;
+            await reassignAll(personId, { ...body, confirmMerge: true });
+          } else throw e;
+        }
+        toast.success("Merged. This person no longer exists on their own.");
+        // Preserve whatever list filter the user came from (e.g. "unnamed
+        // only") — this used to hardcode the default-filter URL, silently
+        // dropping the user back into "Named people" mid-review.
+        const backHref = returnFilter ? `/face-review?filter=${encodeURIComponent(returnFilter)}` : "/face-review";
+        setTimeout(() => (window.location.href = backHref), 900);
+      } else {
+        const res = await strangerAll(personId);
+        toast.success(`Renamed to ${res.name}`);
+        setTimeout(() => window.location.reload(), 800);
+      }
+    } catch (e: any) {
+      toast.error(`Failed: ${e?.error || e?.message || "unknown"}`);
+    } finally {
+      setGlobalBusy(false);
+    }
+  };
+
+  const totalPages = Math.max(1, Math.ceil((query.data?.total ?? 0) / perPage));
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* controls — tab bar + filters on one row (#3) */}
+      <div className="flex flex-wrap items-center gap-3">
+        <ReviewTabs tab={tab} sub={sub} scope={scope} setParams={setParams} />
+        {selectMode ? (
+          <div className="ml-auto flex items-center gap-2">
+            <Button size="sm" variant="outline" onClick={selection.selectAll}>Select all</Button>
+            <Button size="sm" variant="outline" onClick={selection.clear}>Deselect all</Button>
+          </div>
+        ) : (
+          <>
+            <label className="text-sm text-muted-foreground">Show</label>
+            <Select value={show} onValueChange={(v) => { setShow(v as any); setPage(1); setRemoved(new Set()); }}>
+              <SelectTrigger className="w-40 h-8"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All faces</SelectItem>
+                <SelectItem value="prebirth">Before birth date</SelectItem>
+              </SelectContent>
+            </Select>
+            {show !== "prebirth" && (
+              <>
+                <label className="text-sm text-muted-foreground">Sort</label>
+                <Select value={sort} onValueChange={(v) => { setSort(v as ISort); setPage(1); setRemoved(new Set()); }}>
+                  <SelectTrigger className="w-44 h-8"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="confidence">Least typical first</SelectItem>
+                    <SelectItem value="recent">Newest</SelectItem>
+                    <SelectItem value="oldest">Oldest</SelectItem>
+                  </SelectContent>
+                </Select>
+              </>
+            )}
+            <label className="text-sm text-muted-foreground">Per page</label>
+            <Select value={String(perPage)} onValueChange={(v) => { setPerPage(+v); setPage(1); setRemoved(new Set()); }}>
+              <SelectTrigger className="w-20 h-8"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {[25, 50, 100, 200].map((n) => (
+                  <SelectItem key={n} value={String(n)}>{n}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <div className="ml-auto flex items-center gap-2">
+              <Button size="sm" variant="ghost" onClick={() => setGlobalOpen((o) => !o)}>
+                Whole person <ChevronDown size={14} className="ml-1" />
+              </Button>
+              {/* One Select button (#4) instead of a Select under every crop. */}
+              <Button size="sm" variant="outline" onClick={() => { setGlobalOpen(false); setSelectMode(true); }}>
+                Select
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+
+      {show === "prebirth" && !query.data?.birthDate && !query.isLoading && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+          {personName || "This person"} has no birth date in Immich, so there&apos;s nothing to
+          compare capture dates against. Set it in Immich → People → edit → Date of birth.
+        </div>
+      )}
+
+      {globalOpen && (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-card px-4 py-3">
+          <span className="text-sm font-semibold text-muted-foreground">Whole person:</span>
+          <PersonNameInput value={globalTarget} onChange={setGlobalTarget} onSubmit={(v) => wholePerson("reassign", v)} />
+          <Button size="sm" disabled={globalBusy} onClick={() => wholePerson("reassign")}>
+            {globalBusy && <Loader2 className="mr-1 h-3 w-3 animate-spin" />} Reassign all
+          </Button>
+          <Button size="sm" variant="secondary" disabled={globalBusy} onClick={() => wholePerson("stranger")}>
+            Mark as stranger
+          </Button>
+        </div>
+      )}
+
+      {selectMode && (
+        <BulkBar
+          selectedIds={[...selection.selected]}
+          onDone={afterWrite}
+          onCancel={exitSelectMode}
+          hint="Click crops to select · shift-click for a range"
+        />
+      )}
+
+      {query.isLoading ? (
+        <div className="flex justify-center py-16"><Loader2 className="animate-spin" /></div>
+      ) : !visibleFaces.length ? (
+        <div className="py-16 text-center text-muted-foreground">
+          Nothing left to review in this view 🎉
+        </div>
+      ) : (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(190px,1fr))] gap-4">
+          {visibleFaces.map((face) => (
+            <FaceCard
+              key={face.faceId}
+              face={face}
+              selected={selection.selected.has(face.faceId)}
+              onCropClick={(e) => {
+                if (selectMode) selection.toggle(face.faceId, e.shiftKey);
+                else setLightboxAsset(face.assetId);
+              }}
+            >
+              {selectMode ? (
+                <div className="mt-2">
+                  <Button
+                    size="sm"
+                    variant={selection.selected.has(face.faceId) ? "default" : "outline"}
+                    className="w-full h-7 text-xs"
+                    onClick={(e) => selection.toggle(face.faceId, e.shiftKey)}
+                  >
+                    {selection.selected.has(face.faceId) ? "✓ Selected" : "Select"}
+                  </Button>
+                </div>
+              ) : (
+                <div className="mt-2 flex flex-col gap-1">
+                  <Button
+                    size="sm" variant="destructive" className="w-full h-7 text-xs"
+                    onClick={() => {
+                      setOpenMenuFace(openMenuFace === face.faceId ? null : face.faceId);
+                      setMenuTarget({ name: "" });
+                    }}
+                  >
+                    Not {personName || "them"}
+                  </Button>
+                  {openMenuFace === face.faceId && (
+                    <div className="flex flex-col gap-1 rounded-md border bg-muted/40 p-2">
+                      <PersonNameInput
+                        value={menuTarget}
+                        onChange={setMenuTarget}
+                        onSubmit={(v) => singleAction(face, "assign", v)}
+                        className="min-w-0"
+                      />
+                      <Button size="sm" className="h-7 text-xs" disabled={menuBusy} onClick={() => singleAction(face, "assign")}>
+                        {menuBusy && <Loader2 className="mr-1 h-3 w-3 animate-spin" />} Assign name
+                      </Button>
+                      <Button size="sm" variant="secondary" className="h-7 text-xs" disabled={menuBusy} onClick={() => singleAction(face, "stranger")}>
+                        I don&apos;t know this person
+                      </Button>
+                      <Button
+                        size="sm" variant="ghost" className="h-7 text-xs" disabled={menuBusy}
+                        title="Hide this detection — it isn't a real face (statue, pet, blur). Reversible."
+                        onClick={() => singleAction(face, "hide")}
+                      >
+                        Not a face
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </FaceCard>
+          ))}
+        </div>
+      )}
+
+      <Pager page={page} totalPages={totalPages} onPage={(p) => { setPage(p); setRemoved(new Set()); selection.clear(); }} />
+      <Lightbox assetId={lightboxAsset} onClose={() => setLightboxAsset(null)} />
+    </div>
+  );
+}

--- a/src/components/face-review/rejectList.ts
+++ b/src/components/face-review/rejectList.ts
@@ -1,0 +1,40 @@
+/**
+ * Per-person, per-browser "not them" list for the Find More tab — reviewer
+ * scratch state, deliberately NOT written to Immich (a "no" is a judgment
+ * about a suggestion, not a correction). Kept in localStorage so rejected
+ * candidates never resurface on this device; the server excludes ids passed
+ * in the request body. Same design as the source tool.
+ */
+const KEY = (personId: string) => `fr_reject_${personId}`;
+const CAP = 10000;
+
+export function loadRejects(personId: string): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    return new Set(JSON.parse(localStorage.getItem(KEY(personId)) || "[]"));
+  } catch {
+    return new Set();
+  }
+}
+
+export function saveRejects(personId: string, set: Set<string>) {
+  if (typeof window === "undefined") return;
+  let arr = [...set];
+  if (arr.length > CAP) arr = arr.slice(arr.length - CAP);
+  try {
+    localStorage.setItem(KEY(personId), JSON.stringify(arr));
+  } catch {
+    /* quota — losing scratch state is acceptable */
+  }
+}
+
+export function addRejects(personId: string, ids: string[]) {
+  const set = loadRejects(personId);
+  ids.forEach((id) => set.add(id));
+  saveRejects(personId, set);
+}
+
+export function clearRejects(personId: string) {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(KEY(personId));
+}

--- a/src/components/face-review/useFaceSelection.ts
+++ b/src/components/face-review/useFaceSelection.ts
@@ -1,0 +1,50 @@
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Multi-select over a rendered face list with shift-click range support.
+ * The anchor is the last plainly-clicked face; a shift-click selects the
+ * whole range between anchor and target in the CURRENT list order. The
+ * anchor resets whenever the visible face set changes (page, cluster,
+ * refetch) so a range can never span a stale layout.
+ */
+export function useFaceSelection(orderedIds: string[]) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const anchorRef = useRef<string | null>(null);
+
+  const clear = useCallback(() => {
+    setSelected(new Set());
+    anchorRef.current = null;
+  }, []);
+
+  const toggle = useCallback((faceId: string, shiftKey = false) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (shiftKey && anchorRef.current && anchorRef.current !== faceId) {
+        const i1 = orderedIds.indexOf(anchorRef.current);
+        const i2 = orderedIds.indexOf(faceId);
+        if (i1 !== -1 && i2 !== -1) {
+          const [lo, hi] = i1 < i2 ? [i1, i2] : [i2, i1];
+          for (let i = lo; i <= hi; i++) next.add(orderedIds[i]);
+          anchorRef.current = faceId;
+          return next;
+        }
+      }
+      if (next.has(faceId)) next.delete(faceId);
+      else next.add(faceId);
+      anchorRef.current = faceId;
+      return next;
+    });
+  }, [orderedIds]);
+
+  const selectAll = useCallback(() => {
+    setSelected(new Set(orderedIds));
+    anchorRef.current = orderedIds[orderedIds.length - 1] ?? null;
+  }, [orderedIds]);
+
+  const selectMany = useCallback((ids: string[]) => {
+    setSelected(new Set(ids));
+    anchorRef.current = null;
+  }, []);
+
+  return { selected, toggle, selectAll, selectMany, clear };
+}

--- a/src/config/constants/sidebarNavs.tsx
+++ b/src/config/constants/sidebarNavs.tsx
@@ -1,4 +1,4 @@
-import { Copy, GalleryHorizontal, GalleryVerticalEnd, Image as ImageIcon, MapPin, MapPinX, PackageSearch, Rewind, Search, Settings, Share2, User, Video, Workflow } from "lucide-react";
+import { Copy, GalleryHorizontal, GalleryVerticalEnd, Image as ImageIcon, MapPin, MapPinX, PackageSearch, Rewind, ScanFace, Search, Settings, Share2, User, Video, Workflow } from "lucide-react";
 
 interface SidebarNav {
   title: string;
@@ -30,6 +30,7 @@ export const sidebarGroups: SidebarGroup[] = [
       { title: "Empty Videos", link: "/assets/empty-videos", icon: <Video className="h-4 w-4" /> },
       { title: "Bulk Duplicate Finder", link: "/assets/bulk-duplicate-finder", icon: <Copy className="h-4 w-4" /> },
       { title: "Orphan Finder", link: "/assets/orphan-finder", icon: <PackageSearch className="h-4 w-4" /> },
+      { title: "Face Review", link: "/face-review", icon: <ScanFace className="h-4 w-4" />, badge: "Beta" },
     ],
   },
   {

--- a/src/handlers/api/faceReview.handler.ts
+++ b/src/handlers/api/faceReview.handler.ts
@@ -1,0 +1,83 @@
+import API from "@/lib/api";
+import {
+  ICandidateClustersResponse,
+  ICandidatesResponse,
+  IClustersResponse,
+  IFaceReviewScope,
+  IRankedFacesResponse,
+} from "@/types/faceReview";
+
+const BASE = "/api/face-review";
+
+export interface IRankedFacesParams {
+  page: number;
+  perPage: number;
+  sort: "confidence" | "recent" | "oldest";
+  show?: "all" | "prebirth";
+}
+
+export const listFaceReviewPeople = (filter: string) =>
+  API.get(`${BASE}/people`, { filter });
+
+export const getFaceReviewPersonInfo = (personId: string) =>
+  API.get(`${BASE}/people/${personId}/info`);
+
+export const getRankedFaces = (
+  personId: string,
+  params: IRankedFacesParams
+): Promise<IRankedFacesResponse> =>
+  API.get(`${BASE}/people/${personId}/faces`, params);
+
+export const getPersonClusters = (personId: string): Promise<IClustersResponse> =>
+  API.get(`${BASE}/people/${personId}/clusters`);
+
+export const getCandidates = (
+  personId: string,
+  body: { scope: IFaceReviewScope; exclude: string[]; limit: number; offset: number }
+): Promise<ICandidatesResponse> =>
+  API.post(`${BASE}/people/${personId}/candidates`, body);
+
+export const getCandidateClusters = (
+  personId: string,
+  body: { scope: IFaceReviewScope; exclude: string[]; threshold: number }
+): Promise<ICandidateClustersResponse> =>
+  API.post(`${BASE}/people/${personId}/candidate-clusters`, body);
+
+export const getNames = (): Promise<{ id: string; name: string }[]> =>
+  API.get(`${BASE}/names`);
+
+export const reassignFaces = (body: {
+  faceIds: string[];
+  personId?: string;
+  name?: string;
+}): Promise<{ done: number; failed: number; personId: string }> =>
+  API.post(`${BASE}/faces/reassign`, body);
+
+export const strangerFaces = (
+  faceIds: string[]
+): Promise<{ done: number; failed: number; personId: string; name: string }> =>
+  API.post(`${BASE}/faces/stranger`, { faceIds });
+
+export const notAFace = (faceId: string): Promise<{ ok: boolean }> =>
+  API.post(`${BASE}/faces/${faceId}/not-a-face`, {});
+
+export const reassignAll = (
+  personId: string,
+  body: { personId?: string; name?: string; confirmMerge?: boolean }
+): Promise<{ mergedInto: string }> =>
+  API.post(`${BASE}/people/${personId}/reassign-all`, body);
+
+export const strangerAll = (personId: string): Promise<{ name: string }> =>
+  API.post(`${BASE}/people/${personId}/stranger-all`, {});
+
+export const clearEmptyPeople = (): Promise<{ deleted: number }> =>
+  API.post(`${BASE}/clear-empty-people`, {});
+
+export const scanMissing = (): Promise<{ queuedAt: string }> =>
+  API.post(`${BASE}/scan-missing`, {});
+
+/** Facial-recognition queue snapshot: { jobCounts, queueStatus } (for polling scan progress). */
+export const getScanStatus = (): Promise<{
+  jobCounts?: Record<string, number>;
+  queueStatus?: { isActive?: boolean; isPaused?: boolean };
+}> => API.get(`${BASE}/job-status`);

--- a/src/lib/face-review/actions.ts
+++ b/src/lib/face-review/actions.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared write-path helpers: name resolution and batched face reassignment.
+ * All Immich mutations go through lib/face-review/immich.ts with the
+ * requesting user's credentials; the DB is only read here (name lookup).
+ */
+import { createPerson, reassignFace, setPersonFeatureFace } from "@/lib/face-review/immich";
+import { deleteEmptyPeople, findPersonByName, getFeatureFaceStatus, personOwnedBy } from "@/lib/face-review/queries";
+
+type ImmichUser = { isUsingAPIKey?: boolean; accessToken?: string };
+
+/**
+ * Map a typed name to a person id: exact case-insensitive match among the
+ * owner's people wins; otherwise create a new person with that name.
+ */
+export async function resolveOrCreatePerson(
+  user: ImmichUser,
+  ownerId: string,
+  name: string
+): Promise<{ id: string; matchedExisting: boolean }> {
+  const trimmed = (name || "").trim();
+  if (!trimmed) throw new Error("Empty name");
+  const existing = await findPersonByName(ownerId, trimmed);
+  if (existing) return { id: existing, matchedExisting: true };
+  const created = await createPerson(user, trimmed);
+  return { id: created.id, matchedExisting: false };
+}
+
+/**
+ * Resolve the reassign target from a request body carrying either personId
+ * or a free-typed name. A personId is verified to belong to the owner — the
+ * Immich API would also reject a foreign target, but failing early keeps the
+ * error comprehensible.
+ */
+export async function resolveTarget(
+  user: ImmichUser,
+  ownerId: string,
+  body: { personId?: string; name?: string }
+): Promise<{ id: string; matchedExisting: boolean }> {
+  if (body.personId) {
+    if (!(await personOwnedBy(body.personId, ownerId))) {
+      throw new Error("Target person not found");
+    }
+    return { id: body.personId, matchedExisting: true };
+  }
+  return resolveOrCreatePerson(user, ownerId, body.name || "");
+}
+
+/**
+ * Reassign faces one by one (no reliable bulk endpoint), tallying failures.
+ *
+ * Immich leaves the vacated source person behind even at zero faces — it
+ * never auto-deletes a person record just because its last face moved away
+ * (confirmed against a live v3 instance: reassigning a single-face person's
+ * only photo elsewhere leaves a 0-face person record sitting in "Unnamed").
+ * ownerId, when given, sweeps those empty husks after the batch — the same
+ * owner-scoped query "Delete empty people" already runs manually, just
+ * folded into the normal reassign/stranger flow so a single-face person
+ * doesn't need a separate manual cleanup click every time.
+ */
+export async function reassignFaces(
+  user: ImmichUser,
+  faceIds: string[],
+  targetPersonId: string,
+  ownerId?: string
+): Promise<{ done: number; failed: number }> {
+  let done = 0, failed = 0;
+  for (const faceId of faceIds) {
+    try {
+      await reassignFace(user, faceId, targetPersonId);
+      done++;
+    } catch {
+      failed++;
+    }
+  }
+  if (done > 0 && ownerId) await deleteEmptyPeople(ownerId).catch(() => {});
+  return { done, failed };
+}
+
+/**
+ * mergePerson() never gives the target a cover photo if it had none — unlike
+ * Immich's own per-face reassign endpoints, which self-heal a null
+ * faceAssetId by picking a random remaining face (confirmed in Immich's
+ * person.service.js: reassignFaces()/reassignFacesById() call
+ * createNewFeaturePhoto() when faceAssetId is null; mergePerson() just
+ * reassigns faces and deletes the source, nothing else). So a person born
+ * via resolveOrCreatePerson()+mergePerson() (the "name this whole person"
+ * flow, when the typed name doesn't match anyone) is stuck with no
+ * thumbnail forever. This mirrors Immich's own self-heal: pick one of the
+ * person's own visible faces and set it as the feature face, which queues
+ * Immich's thumbnail job. No-ops if a feature face is already set.
+ */
+export async function ensurePersonThumbnail(user: ImmichUser, personId: string, ownerId: string): Promise<void> {
+  const { hasFeatureFace, sampleAssetId } = await getFeatureFaceStatus(personId, ownerId);
+  if (hasFeatureFace || !sampleAssetId) return;
+  await setPersonFeatureFace(user, personId, sampleAssetId);
+}
+
+export function parseFaceIds(body: any): string[] {
+  const ids = Array.isArray(body?.faceIds) ? body.faceIds : [];
+  return ids.filter((x: unknown) => typeof x === "string" && /^[0-9a-f-]{36}$/i.test(x as string));
+}

--- a/src/lib/face-review/cluster.ts
+++ b/src/lib/face-review/cluster.ts
@@ -1,0 +1,166 @@
+/**
+ * Face clustering engine: single-linkage connected components over the graph
+ * where an edge joins two faces iff cosine similarity >= threshold.
+ *
+ * The O(n^2) similarity pass runs in pure JS on worker_threads over a
+ * SharedArrayBuffer, with a 4-way unrolled dot product. Deliberately NOT SQL
+ * and NOT a native/WASM dependency:
+ *  - SQL was measured on live data (~5.1k-face person, Immich pgvector) at
+ *    49s (pairwise self-join) and 183s (per-face LATERAL over the ANN index —
+ *    the index can't help inside one person's rows). Unusable.
+ *  - This implementation measures ~0.8s for the same person on 8 workers
+ *    (M1 Max), matching a numpy BLAS baseline (~0.75s) with zero deps, and
+ *    produced bit-identical clusters (same 233,459 edges, 84 clusters /
+ *    1,132 singletons at threshold 0.65).
+ *
+ * The similarity matrix is never materialized: edges above threshold stream
+ * into worker-local buffers (233k edges for 5k faces vs a ~100MB matrix).
+ */
+import os from "node:os";
+import { Worker } from "node:worker_threads";
+
+export interface ClusterOptions {
+  /** Cosine similarity two faces need to land in one cluster. */
+  threshold: number;
+  /** Components smaller than this are folded into singletonCount. */
+  minClusterSize: number;
+  /** Hard ceiling — O(n^2) work; throw rather than melt on a pathological person. */
+  maxFaces?: number;
+}
+
+export interface ClusterOutput {
+  /** Each cluster is a list of row indexes into the caller's face list,
+   * largest cluster first. */
+  clusters: number[][];
+  singletonCount: number;
+}
+
+export const DEFAULT_THRESHOLD = 0.65;
+export const DEFAULT_MIN_CLUSTER_SIZE = 2;
+export const DEFAULT_MAX_FACES = 8000;
+
+// Worker source as a self-contained string: API routes are bundled by Next,
+// and an eval-worker avoids having to teach the bundler about a separate
+// worker entry file. The code is small and has no imports beyond
+// worker_threads itself.
+const WORKER_SRC = `
+const { parentPort, workerData } = require("node:worker_threads");
+const { sab, n, d, threshold, start, step } = workerData;
+const M = new Float32Array(sab);
+let cap = 1 << 16, len = 0;
+let edges = new Int32Array(cap);
+const push = (i, j) => {
+  if (len + 2 > cap) { cap *= 2; const e2 = new Int32Array(cap); e2.set(edges); edges = e2; }
+  edges[len++] = i; edges[len++] = j;
+};
+// Row-interleaved upper triangle: worker w handles rows w, w+P, w+2P, ...
+// which balances the shrinking triangle without cost modeling.
+for (let i = start; i < n; i += step) {
+  const offI = i * d;
+  for (let j = i + 1; j < n; j++) {
+    const offJ = j * d;
+    let s0 = 0, s1 = 0, s2 = 0, s3 = 0;
+    for (let k = 0; k < d; k += 4) {
+      s0 += M[offI + k]     * M[offJ + k];
+      s1 += M[offI + k + 1] * M[offJ + k + 1];
+      s2 += M[offI + k + 2] * M[offJ + k + 2];
+      s3 += M[offI + k + 3] * M[offJ + k + 3];
+    }
+    if (s0 + s1 + s2 + s3 >= threshold) push(i, j);
+  }
+}
+const out = edges.slice(0, len);
+parentPort.postMessage(out, [out.buffer]);
+`;
+
+// One clustering run at a time per process: each run already saturates the
+// machine with its own worker pool, so concurrent runs would only thrash.
+let queue: Promise<unknown> = Promise.resolve();
+function withClusterLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = queue.then(fn, fn);
+  queue = run.catch(() => {});
+  return run;
+}
+
+function workerCount(): number {
+  return Math.max(1, Math.min(8, os.cpus().length - 2));
+}
+
+/**
+ * @param embeddings row-major n x d matrix. Rows need NOT be normalized —
+ *   normalization happens here so callers can pass raw pgvector values.
+ */
+export function clusterEmbeddings(
+  embeddings: Float32Array,
+  n: number,
+  d: number,
+  opts: ClusterOptions
+): Promise<ClusterOutput> {
+  const { threshold, minClusterSize, maxFaces = DEFAULT_MAX_FACES } = opts;
+  if (n * d !== embeddings.length) {
+    throw new Error(`embeddings length ${embeddings.length} != n*d (${n}*${d})`);
+  }
+  if (n > maxFaces) {
+    throw new Error(
+      `Too many faces to cluster (${n} > ${maxFaces}) — the similarity pass is O(n^2) in time and memory.`
+    );
+  }
+  return withClusterLock(async () => {
+    if (n < 2) return { clusters: [], singletonCount: n };
+
+    // Copy into a SharedArrayBuffer, normalizing each row.
+    const sab = new SharedArrayBuffer(n * d * 4);
+    const M = new Float32Array(sab);
+    for (let i = 0; i < n; i++) {
+      const off = i * d;
+      let norm = 0;
+      for (let k = 0; k < d; k++) norm += embeddings[off + k] * embeddings[off + k];
+      norm = Math.sqrt(norm) || 1;
+      for (let k = 0; k < d; k++) M[off + k] = embeddings[off + k] / norm;
+    }
+
+    const P = workerCount();
+    const edgeLists = await Promise.all(
+      Array.from({ length: P }, (_, w) =>
+        new Promise<Int32Array>((resolve, reject) => {
+          const wk = new Worker(WORKER_SRC, {
+            eval: true,
+            workerData: { sab, n, d, threshold, start: w, step: P },
+          });
+          wk.once("message", (m: Int32Array) => { resolve(m); void wk.terminate(); });
+          wk.once("error", reject);
+        })
+      )
+    );
+
+    // Union-find over the merged edge lists (trivially fast: ~3ms / 233k edges).
+    const parent = new Int32Array(n);
+    for (let i = 0; i < n; i++) parent[i] = i;
+    const find = (x: number): number => {
+      while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; }
+      return x;
+    };
+    for (const list of edgeLists) {
+      for (let e = 0; e < list.length; e += 2) {
+        const ri = find(list[e]), rj = find(list[e + 1]);
+        if (ri !== rj) parent[ri] = rj;
+      }
+    }
+
+    const members = new Map<number, number[]>();
+    for (let i = 0; i < n; i++) {
+      const r = find(i);
+      const arr = members.get(r);
+      if (arr) arr.push(i);
+      else members.set(r, [i]);
+    }
+    const clusters: number[][] = [];
+    let singletonCount = 0;
+    for (const group of members.values()) {
+      if (group.length >= minClusterSize) clusters.push(group);
+      else singletonCount += group.length;
+    }
+    clusters.sort((a, b) => b.length - a.length);
+    return { clusters, singletonCount };
+  });
+}

--- a/src/lib/face-review/immich.ts
+++ b/src/lib/face-review/immich.ts
@@ -1,0 +1,79 @@
+/**
+ * Server-side Immich API calls for Face Review writes, made with the
+ * requesting user's own credentials (cookie session or API key) so Immich's
+ * own authorization stays authoritative for every mutation.
+ */
+import { ENV } from "@/config/environment";
+import { getUserHeaders } from "@/helpers/user.helper";
+
+type ImmichUser = { isUsingAPIKey?: boolean; accessToken?: string };
+
+async function immich(
+  user: ImmichUser,
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<any> {
+  const res = await fetch(`${ENV.IMMICH_URL}/api${path}`, {
+    method,
+    headers: getUserHeaders(user),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Immich ${method} ${path} -> ${res.status}${text ? `: ${text.slice(0, 300)}` : ""}`);
+  }
+  const ct = res.headers.get("content-type") || "";
+  return ct.includes("application/json") ? res.json() : res.text();
+}
+
+/**
+ * Reassign one detected face to a person.
+ *
+ * !! ENDPOINT SHAPE FOOTGUN — verified against a live v3 instance by the
+ * source tool after the intuitive shape failed: despite the name
+ * `PUT /faces/{id}`, the URL param is the TARGET PERSON id and the body
+ * carries the face: `{"id": "<faceId>"}`. Getting this backwards reassigns
+ * the wrong entity. Do not "fix" the argument order.
+ */
+export function reassignFace(user: ImmichUser, faceId: string, targetPersonId: string) {
+  return immich(user, "PUT", `/faces/${targetPersonId}`, { id: faceId });
+}
+
+export function createPerson(user: ImmichUser, name = ""): Promise<{ id: string; name: string }> {
+  return immich(user, "POST", "/people", { name });
+}
+
+export function updatePersonName(user: ImmichUser, personId: string, name: string) {
+  return immich(user, "PUT", `/people/${personId}`, { name });
+}
+
+/** Sets the person's cover-photo source face; Immich queues its own thumbnail-generation job as a side effect. */
+export function setPersonFeatureFace(user: ImmichUser, personId: string, assetId: string) {
+  return immich(user, "PUT", `/people/${personId}`, { featureFaceAssetId: assetId });
+}
+
+export function mergePerson(user: ImmichUser, targetId: string, sourceIds: string[]) {
+  return immich(user, "POST", `/people/${targetId}/merge`, { ids: sourceIds });
+}
+
+/**
+ * Queue Facial Recognition in MISSING mode. Never force=true: "All"
+ * re-clusters from scratch and can overwrite manual corrections (documented
+ * Immich behavior). Also note: job commands are PUT /jobs/{name} — POST is
+ * a different endpoint entirely.
+ */
+export function runFacialRecognitionMissing(user: ImmichUser) {
+  return immich(user, "PUT", "/jobs/facialRecognition", { command: "start", force: false });
+}
+
+export function getJobStatus(user: ImmichUser) {
+  return immich(user, "GET", "/jobs");
+}
+
+export const STRANGER_PREFIX = "Stranger ";
+
+/** Unique per-split label, e.g. "Stranger 3f9a" — same scheme as the source tool. */
+export function strangerName(): string {
+  return `${STRANGER_PREFIX}${crypto.randomUUID().replace(/-/g, "").slice(0, 4)}`;
+}

--- a/src/lib/face-review/queries.ts
+++ b/src/lib/face-review/queries.ts
@@ -1,0 +1,462 @@
+/**
+ * Face Review read queries. Ported from the standalone immich-face-review
+ * tool's db.py, whose non-obvious behaviors were verified against a live
+ * multi-user Immich v3 instance. Two rules carried over verbatim:
+ *
+ * 1. OWNER SCOPING IS MANDATORY. The person/asset tables are instance-wide;
+ *    every query keyed by an id from the URL either takes ownerId or sits
+ *    behind personOwnedBy(). Destructive ops fail closed without an owner.
+ * 2. Trashed assets leave orphaned asset_face rows behind (Immich soft
+ *    delete), which break API reassignment and skew centroid math — every
+ *    query filters a."deletedAt" IS NULL.
+ *
+ * "Confidence" here = cosine distance from the person's centroid embedding
+ * (Immich does not persist detection confidence; embeddings in face_search
+ * are the only signal). Higher distance = less typical = review first.
+ */
+import { sql } from "drizzle-orm";
+
+import { db } from "@/config/db";
+import {
+  clusterEmbeddings,
+  DEFAULT_MAX_FACES,
+  DEFAULT_MIN_CLUSTER_SIZE,
+  DEFAULT_THRESHOLD,
+} from "@/lib/face-review/cluster";
+import { IFaceCluster, IFaceReviewFace, IFaceReviewScope } from "@/types/faceReview";
+
+export const STRANGER_PREFIXES = ["Stranger ", "Rando "] as const;
+
+/**
+ * Only faces on assets the owner can actually SEE belong in review. Immich
+ * v3 visibility states, verified against a live instance (thumbnail + asset
+ * endpoints, owner's own credentials):
+ *   timeline -> 200, archive -> 200, locked -> 400, hidden -> 404.
+ * `locked` is the PIN-protected Locked Folder — deliberately concealed, so
+ * surfacing even its face metadata here would be a privacy leak (and its
+ * crops render as "load failed" since the thumbnail proxy 400s). `hidden`
+ * is internal (e.g. motion-photo video parts). Archived photos stay fully
+ * reviewable. This predicate must accompany EVERY join against asset.
+ */
+const VIEWABLE = sql`a.visibility IN ('timeline', 'archive')`;
+
+const toDateStr = (v: unknown): string | null => {
+  if (!v) return null;
+  const d = v instanceof Date ? v : new Date(String(v));
+  return isNaN(d.getTime()) ? null : d.toISOString().slice(0, 10);
+};
+
+const rowToFace = (r: any): IFaceReviewFace => ({
+  faceId: r.face_id,
+  assetId: r.asset_id,
+  distance: r.distance === null || r.distance === undefined ? null : Math.round(+r.distance * 10000) / 10000,
+  takenAt: toDateStr(r.taken_at),
+  boundingBoxX1: r.x1, boundingBoxY1: r.y1, boundingBoxX2: r.x2, boundingBoxY2: r.y2,
+  imageWidth: r.image_w, imageHeight: r.image_h,
+  ...(r.cur_person_id !== undefined
+    ? { curPersonId: r.cur_person_id, curName: (r.cur_name || "").trim() || null }
+    : {}),
+});
+
+/** Gate for every person-scoped route: does this person belong to this owner? */
+export async function personOwnedBy(personId: string, ownerId: string): Promise<boolean> {
+  const { rows } = await db.execute(sql`
+    SELECT 1 FROM person WHERE id = ${personId} AND "ownerId" = ${ownerId} LIMIT 1
+  `);
+  return rows.length > 0;
+}
+
+export async function getPersonMeta(personId: string, ownerId: string) {
+  const { rows } = await db.execute(sql`
+    SELECT p.name, p."birthDate" AS birth_date, p."isHidden" AS is_hidden,
+           COUNT(a.id)::int AS face_count
+      FROM person p
+      LEFT JOIN asset_face af
+        ON af."personId" = p.id AND af."isVisible" = true AND af."deletedAt" IS NULL
+      LEFT JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE}
+     WHERE p.id = ${personId} AND p."ownerId" = ${ownerId}
+     GROUP BY p.id
+  `);
+  const r: any = rows[0];
+  if (!r) return null;
+  return {
+    name: (r.name || "").trim(),
+    birthDate: toDateStr(r.birth_date),
+    isHidden: !!r.is_hidden,
+    faceCount: +r.face_count,
+  };
+}
+
+const CENTROID_CTE = (personId: string) => sql`
+  WITH centroid AS (
+    SELECT AVG(fs.embedding) AS c
+      FROM asset_face af
+      JOIN face_search fs ON fs."faceId" = af.id
+      JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE}
+     WHERE af."personId" = ${personId}
+       AND af."isVisible" = true AND af."deletedAt" IS NULL
+  )
+`;
+
+export type IRankedSort = "confidence" | "recent" | "oldest";
+
+/**
+ * A person's own faces for the Tagged Faces grid. sort=confidence ranks
+ * least-typical first (centroid distance DESC); date sorts come straight
+ * from the DB (the Flask tool needed an N+1 Immich-API fallback for these —
+ * with drizzle in-process there's no reason to leave the DB).
+ * prebirthOnly limits to faces on photos captured before person.birthDate
+ * (camera-local date; UTC fileCreatedAt only as fallback).
+ */
+export async function getRankedFaces(
+  personId: string,
+  ownerId: string,
+  opts: { page: number; perPage: number; sort: IRankedSort; prebirthOnly?: boolean }
+): Promise<{ faces: IFaceReviewFace[]; total: number }> {
+  const { page, perPage, sort, prebirthOnly } = opts;
+  const orderBy =
+    sort === "recent" ? sql`taken_at DESC NULLS LAST`
+    : sort === "oldest" ? sql`taken_at ASC NULLS LAST`
+    : sql`distance DESC NULLS LAST`;
+  const prebirth = prebirthOnly
+    ? sql`AND p."birthDate" IS NOT NULL
+          AND COALESCE(a."localDateTime", a."fileCreatedAt")::date < p."birthDate"`
+    : sql``;
+  const { rows } = await db.execute(sql`
+    ${CENTROID_CTE(personId)}
+    SELECT af.id::text AS face_id, af."assetId"::text AS asset_id,
+           (fs.embedding <=> centroid.c) AS distance,
+           af."boundingBoxX1" AS x1, af."boundingBoxY1" AS y1,
+           af."boundingBoxX2" AS x2, af."boundingBoxY2" AS y2,
+           af."imageWidth" AS image_w, af."imageHeight" AS image_h,
+           COALESCE(a."localDateTime", a."fileCreatedAt") AS taken_at,
+           COUNT(*) OVER()::int AS total
+      FROM asset_face af
+      LEFT JOIN face_search fs ON fs."faceId" = af.id
+      JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE} AND a."ownerId" = ${ownerId}
+      JOIN person p ON p.id = af."personId"
+      CROSS JOIN centroid
+     WHERE af."personId" = ${personId}
+       AND af."isVisible" = true AND af."deletedAt" IS NULL
+       ${prebirth}
+     ORDER BY ${orderBy}
+     LIMIT ${perPage} OFFSET ${(page - 1) * perPage}
+  `);
+  const total = rows.length ? +(rows[0] as any).total : 0;
+  return { faces: rows.map(rowToFace), total };
+}
+
+interface EmbeddedFaceRow { face: IFaceReviewFace; emb: string }
+
+async function fetchOwnFaceEmbeddings(personId: string, ownerId: string): Promise<EmbeddedFaceRow[]> {
+  const { rows } = await db.execute(sql`
+    ${CENTROID_CTE(personId)}
+    SELECT af.id::text AS face_id, af."assetId"::text AS asset_id,
+           (fs.embedding <=> centroid.c) AS distance,
+           af."boundingBoxX1" AS x1, af."boundingBoxY1" AS y1,
+           af."boundingBoxX2" AS x2, af."boundingBoxY2" AS y2,
+           af."imageWidth" AS image_w, af."imageHeight" AS image_h,
+           COALESCE(a."localDateTime", a."fileCreatedAt") AS taken_at,
+           fs.embedding::text AS emb
+      FROM asset_face af
+      JOIN face_search fs ON fs."faceId" = af.id
+      JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE} AND a."ownerId" = ${ownerId}
+      CROSS JOIN centroid
+     WHERE af."personId" = ${personId}
+       AND af."isVisible" = true AND af."deletedAt" IS NULL
+  `);
+  return rows.map((r: any) => ({ face: rowToFace(r), emb: r.emb }));
+}
+
+function parseEmbeddings(rows: EmbeddedFaceRow[]): { M: Float32Array; d: number } {
+  const first: number[] = JSON.parse(rows[0].emb);
+  const d = first.length;
+  const M = new Float32Array(rows.length * d);
+  M.set(first, 0);
+  for (let i = 1; i < rows.length; i++) {
+    const v: number[] = JSON.parse(rows[i].emb);
+    M.set(v, i * d);
+  }
+  return { M, d };
+}
+
+function toClusterList(
+  groups: number[][],
+  rows: EmbeddedFaceRow[],
+  sortByMeanDistance: boolean
+): IFaceCluster[] {
+  const clusters = groups.map((group) => {
+    const faces = group.map((i) => rows[i].face);
+    const dists = faces.map((f) => f.distance).filter((x): x is number => x !== null);
+    const meanDistance = dists.length
+      ? Math.round((dists.reduce((a, b) => a + b, 0) / dists.length) * 10000) / 10000
+      : null;
+    return { size: faces.length, meanDistance, faces };
+  });
+  if (sortByMeanDistance) {
+    clusters.sort((a, b) => (a.meanDistance ?? Infinity) - (b.meanDistance ?? Infinity));
+  }
+  return clusters.map((c, idx) => ({ index: idx + 1, ...c }));
+}
+
+/**
+ * Cluster a person's OWN faces by mutual similarity — catches a wrongly-
+ * merged different person as a tight sub-group, the one failure mode
+ * centroid-distance ranking structurally can't see (a wrong sub-group big
+ * enough shifts the centroid toward itself).
+ */
+export async function getPersonClusters(
+  personId: string,
+  ownerId: string,
+  opts?: { threshold?: number; minClusterSize?: number; maxFaces?: number }
+): Promise<{ clusters: IFaceCluster[]; singletonCount: number; totalFaces: number; threshold: number }> {
+  const threshold = opts?.threshold ?? DEFAULT_THRESHOLD;
+  const rows = await fetchOwnFaceEmbeddings(personId, ownerId);
+  if (rows.length < 2) {
+    return { clusters: [], singletonCount: rows.length, totalFaces: rows.length, threshold };
+  }
+  const { M, d } = parseEmbeddings(rows);
+  const { clusters, singletonCount } = await clusterEmbeddings(M, rows.length, d, {
+    threshold,
+    minClusterSize: opts?.minClusterSize ?? DEFAULT_MIN_CLUSTER_SIZE,
+    maxFaces: opts?.maxFaces ?? DEFAULT_MAX_FACES,
+  });
+  // Own-face clusters: biggest first (engine default order).
+  return { clusters: toClusterList(clusters, rows, false), singletonCount, totalFaces: rows.length, threshold };
+}
+
+const scopeCondition = (scope: IFaceReviewScope) =>
+  scope === "named"
+    ? // ONLY faces already assigned to another real-named person (not
+      // empty-name, not a Stranger/Rando split-off): candidates whose "yes"
+      // explicitly moves them away from someone else.
+      sql`AND af."personId" IS NOT NULL AND p.name <> ''
+          AND p.name NOT LIKE ${STRANGER_PREFIXES[0] + "%"}
+          AND p.name NOT LIKE ${STRANGER_PREFIXES[1] + "%"}`
+    : // Unknown faces only: unassigned, empty-name person, or a stranger.
+      sql`AND (af."personId" IS NULL OR p.name = ''
+           OR p.name LIKE ${STRANGER_PREFIXES[0] + "%"}
+           OR p.name LIKE ${STRANGER_PREFIXES[1] + "%"})`;
+
+const candidateSelect = (personId: string, ownerId: string, scope: IFaceReviewScope, excludeIds: string[]) => sql`
+  ${CENTROID_CTE(personId)}
+  SELECT af.id::text AS face_id, af."assetId"::text AS asset_id,
+         (fs.embedding <=> centroid.c) AS distance,
+         af."boundingBoxX1" AS x1, af."boundingBoxY1" AS y1,
+         af."boundingBoxX2" AS x2, af."boundingBoxY2" AS y2,
+         af."imageWidth" AS image_w, af."imageHeight" AS image_h,
+         af."personId"::text AS cur_person_id, p.name AS cur_name,
+         COALESCE(a."localDateTime", a."fileCreatedAt") AS taken_at,
+         fs.embedding::text AS emb
+    FROM asset_face af
+    JOIN face_search fs ON fs."faceId" = af.id
+    JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE} AND a."ownerId" = ${ownerId}
+    LEFT JOIN person p ON p.id = af."personId"
+    CROSS JOIN centroid
+   WHERE af."isVisible" = true AND af."deletedAt" IS NULL
+     AND af."personId" IS DISTINCT FROM ${personId}::uuid
+     AND centroid.c IS NOT NULL
+     ${excludeIds.length
+       // Bound as one JSON string: drizzle/node-postgres array binding
+       // doesn't produce a valid uuid[] literal here, so unpack server-side.
+       ? sql`AND af.id <> ALL(ARRAY(SELECT jsonb_array_elements_text(${JSON.stringify(excludeIds)}::jsonb)::uuid))`
+       : sql``}
+     ${scopeCondition(scope)}
+   ORDER BY distance ASC
+`;
+
+/**
+ * "Find more of this person": faces NOT currently this person, ranked by
+ * distance to the person's centroid, closest (most likely) first. An exact
+ * scan on purpose — the ANN index returns too few rows once the person's own
+ * faces (the true nearest neighbours) are excluded. ~0.6s over ~45k faces.
+ * excludeIds carries the reviewer's browser-local reject list.
+ */
+export async function getCandidateFaces(
+  personId: string,
+  ownerId: string,
+  opts: { scope: IFaceReviewScope; excludeIds: string[]; limit: number; offset: number }
+): Promise<{ candidates: IFaceReviewFace[]; hasNext: boolean }> {
+  const { rows } = await db.execute(sql`
+    SELECT * FROM (${candidateSelect(personId, ownerId, opts.scope, opts.excludeIds)}) q
+    LIMIT ${opts.limit + 1} OFFSET ${opts.offset}
+  `);
+  const hasNext = rows.length > opts.limit;
+  return { candidates: rows.slice(0, opts.limit).map(rowToFace), hasNext };
+}
+
+export const CANDIDATE_POOL_SIZE = 2000;
+
+/**
+ * Cluster the closest CANDIDATE faces by similarity to EACH OTHER — surfaces
+ * a missed relative sitting in the pool as many separate photos as one group
+ * instead of many Yes/No decisions. Deliberately partial: only the closest
+ * poolSize candidates (full pool would be O(45k^2)); clusters sorted by mean
+ * distance ascending (most-likely first, unlike own-face clusters).
+ */
+export async function getCandidateClusters(
+  personId: string,
+  ownerId: string,
+  opts: { scope: IFaceReviewScope; excludeIds: string[]; threshold?: number; minClusterSize?: number; poolSize?: number }
+): Promise<{ clusters: IFaceCluster[]; singletonCount: number; poolSize: number; threshold: number }> {
+  const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
+  const poolSize = opts.poolSize ?? CANDIDATE_POOL_SIZE;
+  const { rows } = await db.execute(sql`
+    SELECT * FROM (${candidateSelect(personId, ownerId, opts.scope, opts.excludeIds)}) q
+    LIMIT ${poolSize}
+  `);
+  const embedded: EmbeddedFaceRow[] = rows.map((r: any) => ({ face: rowToFace(r), emb: r.emb }));
+  if (embedded.length < 2) {
+    return { clusters: [], singletonCount: embedded.length, poolSize: embedded.length, threshold };
+  }
+  const { M, d } = parseEmbeddings(embedded);
+  const { clusters, singletonCount } = await clusterEmbeddings(M, embedded.length, d, {
+    threshold,
+    minClusterSize: opts.minClusterSize ?? DEFAULT_MIN_CLUSTER_SIZE,
+    // poolSize bounds n already; no separate maxFaces ceiling here.
+    maxFaces: poolSize,
+  });
+  return {
+    clusters: toClusterList(clusters, embedded, true),
+    singletonCount,
+    poolSize: embedded.length,
+    threshold,
+  };
+}
+
+export type IFaceReviewPeopleFilter = "all" | "named" | "unnamed" | "strangers" | "hidden" | "prebirth";
+
+/** Landing-grid list: this owner's people with visible face counts. */
+export async function getPeopleWithCounts(
+  ownerId: string,
+  filter: IFaceReviewPeopleFilter
+): Promise<{ id: string; name: string; birthDate: string | null; isHidden: boolean; faceCount: number; prebirthCount?: number }[]> {
+  const nameFilter =
+    filter === "named"
+      ? sql`AND p.name <> '' AND p.name NOT LIKE ${STRANGER_PREFIXES[0] + "%"} AND p.name NOT LIKE ${STRANGER_PREFIXES[1] + "%"}`
+      : filter === "unnamed" ? sql`AND p.name = ''`
+      : filter === "strangers"
+      ? sql`AND (p.name LIKE ${STRANGER_PREFIXES[0] + "%"} OR p.name LIKE ${STRANGER_PREFIXES[1] + "%"})`
+      : sql``;
+  // Hidden people are excluded everywhere except the explicit hidden view.
+  const hiddenFilter = filter === "hidden" ? sql`AND p."isHidden" = true` : sql`AND p."isHidden" = false`;
+  const prebirthJoin =
+    filter === "prebirth"
+      ? sql`AND p."birthDate" IS NOT NULL AND COALESCE(a."localDateTime", a."fileCreatedAt")::date < p."birthDate"`
+      : sql``;
+  // face_count = COUNT(a.id): visible faces on live (non-trashed) assets.
+  // Under the prebirth filter the asset join narrows to pre-birth-date
+  // photos, so the count becomes "prebirth faces" and empty people drop out;
+  // other views keep zero-face people visible (that's what "Delete empty
+  // people" acts on).
+  const { rows } = await db.execute(sql`
+    SELECT p.id::text AS id, p.name, p."birthDate" AS birth_date, p."isHidden" AS is_hidden,
+           COUNT(a.id)::int AS face_count
+      FROM person p
+      LEFT JOIN asset_face af
+        ON af."personId" = p.id AND af."isVisible" = true AND af."deletedAt" IS NULL
+      LEFT JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE} ${prebirthJoin}
+     WHERE p."ownerId" = ${ownerId} ${nameFilter} ${hiddenFilter}
+     GROUP BY p.id
+    ${filter === "prebirth" ? sql`HAVING COUNT(a.id) > 0` : sql``}
+     ORDER BY face_count DESC, p.name ASC
+  `);
+  return rows.map((r: any) => ({
+    id: r.id,
+    name: (r.name || "").trim(),
+    birthDate: toDateStr(r.birth_date),
+    isHidden: !!r.is_hidden,
+    faceCount: +r.face_count,
+  }));
+}
+
+/** Autocomplete source + name resolution: the owner's REAL-named people. */
+export async function getNamedPeople(ownerId: string): Promise<{ id: string; name: string }[]> {
+  const { rows } = await db.execute(sql`
+    SELECT p.id::text AS id, p.name
+      FROM person p
+     WHERE p."ownerId" = ${ownerId} AND p.name <> ''
+       AND p.name NOT LIKE ${STRANGER_PREFIXES[0] + "%"}
+       AND p.name NOT LIKE ${STRANGER_PREFIXES[1] + "%"}
+     ORDER BY LOWER(p.name) ASC
+  `);
+  return rows.map((r: any) => ({ id: r.id, name: (r.name || "").trim() }));
+}
+
+/**
+ * Hide a detection that isn't a real face (statue, pet, blur): what Immich
+ * does internally for hidden faces (isVisible=false + detach) — reversible,
+ * unlike the REST DELETE /faces/{id}, which the source tool never got
+ * live-confirmed. Owner-scoped through the face's asset; PER-FACE only by
+ * design (the removed bulk variant was the accident risk).
+ * Returns false for an unknown/foreign face (no write).
+ */
+export async function hideFace(faceId: string, ownerId: string): Promise<boolean> {
+  if (!ownerId) throw new Error("ownerId required (multi-user DB, refusing unscoped update)");
+  const result = await db.execute(sql`
+    UPDATE asset_face af
+       SET "isVisible" = false, "personId" = NULL
+      FROM asset a
+     WHERE af.id = ${faceId}
+       AND a.id = af."assetId"
+       AND a."ownerId" = ${ownerId}
+       AND a."deletedAt" IS NULL
+  `);
+  return (result.rowCount ?? 0) > 0;
+}
+
+/**
+ * Delete the owner's person records with zero visible, non-deleted faces —
+ * the debris failed/retried reassigns leave behind. ownerId REQUIRED (an
+ * unscoped delete on the shared table would hit other users' records).
+ */
+export async function deleteEmptyPeople(ownerId: string): Promise<number> {
+  if (!ownerId) throw new Error("ownerId required (multi-user DB, refusing unscoped delete)");
+  const result = await db.execute(sql`
+    DELETE FROM person
+     WHERE id IN (
+       SELECT p.id FROM person p
+        WHERE p."ownerId" = ${ownerId}
+          AND NOT EXISTS (
+            SELECT 1 FROM asset_face af
+             WHERE af."personId" = p.id
+               AND af."isVisible" = true
+               AND af."deletedAt" IS NULL
+          )
+     )
+  `);
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Whether a person already has Immich's feature-face pointer set, plus one
+ * of their own visible faces' assetId to use as a fallback if not. See
+ * ensurePersonThumbnail() in actions.ts for why this is needed.
+ */
+export async function getFeatureFaceStatus(
+  personId: string,
+  ownerId: string
+): Promise<{ hasFeatureFace: boolean; sampleAssetId: string | null }> {
+  const { rows } = await db.execute(sql`
+    SELECT p."faceAssetId" IS NOT NULL AS has_feature_face,
+           (SELECT af."assetId"::text
+              FROM asset_face af
+              JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND ${VIEWABLE} AND a."ownerId" = ${ownerId}
+             WHERE af."personId" = p.id AND af."isVisible" = true AND af."deletedAt" IS NULL
+             LIMIT 1) AS sample_asset_id
+      FROM person p
+     WHERE p.id = ${personId} AND p."ownerId" = ${ownerId}
+  `);
+  const r: any = rows[0];
+  return { hasFeatureFace: !!r?.has_feature_face, sampleAssetId: r?.sample_asset_id ?? null };
+}
+
+/** Exact-name match among the owner's people (case-insensitive). */
+export async function findPersonByName(ownerId: string, name: string): Promise<string | null> {
+  const { rows } = await db.execute(sql`
+    SELECT p.id::text AS id FROM person p
+     WHERE p."ownerId" = ${ownerId} AND LOWER(TRIM(p.name)) = LOWER(TRIM(${name}))
+     LIMIT 1
+  `);
+  return rows.length ? (rows[0] as any).id : null;
+}

--- a/src/lib/face-review/route-utils.ts
+++ b/src/lib/face-review/route-utils.ts
@@ -1,0 +1,50 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
+import { personOwnedBy } from "@/lib/face-review/queries";
+
+/**
+ * Resolve the request's user and verify the URL's person belongs to them.
+ * Writes the error response and returns null on failure — the multi-user
+ * Immich DB is instance-wide while auth is per-user, so every person-scoped
+ * Face Review route MUST pass this gate before touching the DB (a foreign
+ * person id must 404, indistinguishable from nonexistent).
+ */
+export interface IFaceReviewUser {
+  id: string;
+  isUsingAPIKey?: boolean;
+  accessToken?: string;
+}
+
+export async function requireOwnedPerson(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<{ ownerId: string; personId: string; user: IFaceReviewUser } | null> {
+  const personId = String(req.query.id || "");
+  if (!/^[0-9a-f-]{36}$/i.test(personId)) {
+    res.status(400).json({ error: "Invalid person id" });
+    return null;
+  }
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser?.id) {
+    res.status(401).json({ error: "Not authenticated" });
+    return null;
+  }
+  if (!(await personOwnedBy(personId, currentUser.id))) {
+    res.status(404).json({ error: "Person not found" });
+    return null;
+  }
+  return { ownerId: currentUser.id, personId, user: currentUser };
+}
+
+export async function requireUser(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<{ ownerId: string; user: IFaceReviewUser } | null> {
+  const currentUser = await getCurrentUser(req);
+  if (!currentUser?.id) {
+    res.status(401).json({ error: "Not authenticated" });
+    return null;
+  }
+  return { ownerId: currentUser.id, user: currentUser };
+}

--- a/src/pages/api/face-review/clear-empty-people.ts
+++ b/src/pages/api/face-review/clear-empty-people.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { deleteEmptyPeople } from "@/lib/face-review/queries";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * Delete the requesting user's person records with zero visible faces —
+ * debris from failed/retried reassigns. Owner-scoped and fail-closed inside
+ * deleteEmptyPeople(); never touches another user's records.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+    const deleted = await deleteEmptyPeople(gate.ownerId);
+    return res.status(200).json({ deleted });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/faces/[faceId]/crop.ts
+++ b/src/pages/api/face-review/faces/[faceId]/crop.ts
@@ -1,0 +1,112 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { sql } from "drizzle-orm";
+import sharp from "sharp";
+
+import { db } from "@/config/db";
+import { ENV } from "@/config/environment";
+import { getUserHeaders } from "@/helpers/user.helper";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * Square face crop, rendered SERVER-side. The client used to download the
+ * asset's whole `preview` (~1440px, hundreds of KB) and crop the face on a
+ * canvas — fine on LAN, brutal remotely. Here the server (LAN-adjacent to
+ * Immich) fetches the preview, does the identical crop math (pad 40%,
+ * square, clamp — see the old FaceCrop.tsx / the source tool's faces.js),
+ * and ships only a ~500px WebP of the face itself.
+ *
+ * A face's bounding box never changes once detected, so the response is
+ * immutable — cache hard.
+ */
+
+// Display is ~200px; 400 = 2x for hi-dpi. 800 kept for possible zoom use.
+const ALLOWED_SIZES = [400, 800];
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).json({ error: "Method Not Allowed" });
+
+  const faceId = String(req.query.faceId || "");
+  if (!/^[0-9a-f-]{36}$/i.test(faceId)) {
+    return res.status(400).json({ error: "Invalid face id" });
+  }
+  const size = ALLOWED_SIZES.includes(+(req.query.s as string)) ? +(req.query.s as string) : 400;
+
+  const gate = await requireUser(req, res);
+  if (!gate) return;
+
+  try {
+    // Owner scoping via the asset join, not the person: Find More renders
+    // faces that belong to *other* (or no) person records, but always on the
+    // requesting user's own assets.
+    const { rows } = await db.execute(sql`
+      SELECT af."assetId"::text AS asset_id,
+             af."boundingBoxX1" AS x1, af."boundingBoxY1" AS y1,
+             af."boundingBoxX2" AS x2, af."boundingBoxY2" AS y2,
+             af."imageWidth" AS image_w, af."imageHeight" AS image_h
+        FROM asset_face af
+        JOIN asset a ON a.id = af."assetId" AND a."deletedAt" IS NULL AND a."ownerId" = ${gate.ownerId}
+       WHERE af.id = ${faceId}
+       LIMIT 1
+    `);
+    const face = rows[0] as
+      | { asset_id: string; x1: number; y1: number; x2: number; y2: number; image_w: number; image_h: number }
+      | undefined;
+    if (!face) return res.status(404).json({ error: "Face not found" });
+
+    const upstream = await fetch(
+      `${ENV.IMMICH_URL}/api/assets/${face.asset_id}/thumbnail?size=preview`,
+      { headers: getUserHeaders(gate.user) }
+    );
+    if (!upstream.ok) {
+      return res.status(502).json({ error: `Preview fetch failed (${upstream.status})` });
+    }
+    const preview = Buffer.from(await upstream.arrayBuffer());
+
+    const img = sharp(preview);
+    const meta = await img.metadata();
+    const W = meta.width ?? 0;
+    const H = meta.height ?? 0;
+
+    let region: { left: number; top: number; width: number; height: number } | null = null;
+    const { x1, y1, x2, y2, image_w: mlW, image_h: mlH } = face;
+    if (W && H && [x1, y1, x2, y2].every((v) => typeof v === "number" && !Number.isNaN(v)) && x2 > x1) {
+      // Same math as the old client-side FaceCrop: bbox lives in the ML
+      // model's coordinate space, so scale to the preview's real size.
+      const scaleX = mlW ? W / mlW : 1;
+      const scaleY = mlH ? H / mlH : 1;
+      let sx = x1 * scaleX;
+      let sy = y1 * scaleY;
+      let sw = (x2 - x1) * scaleX;
+      let sh = (y2 - y1) * scaleY;
+      const padX = sw * 0.4, padY = sh * 0.4;
+      sx = Math.max(0, sx - padX);
+      sy = Math.max(0, sy - padY);
+      sw = Math.min(W - sx, sw + padX * 2);
+      sh = Math.min(H - sy, sh + padY * 2);
+      const cropSize = Math.min(Math.max(sw, sh), W, H);
+      sx = Math.min(Math.max(0, sx + sw / 2 - cropSize / 2), W - cropSize);
+      sy = Math.min(Math.max(0, sy + sh / 2 - cropSize / 2), H - cropSize);
+      region = {
+        left: Math.round(sx),
+        top: Math.round(sy),
+        width: Math.max(1, Math.round(cropSize)),
+        height: Math.max(1, Math.round(cropSize)),
+      };
+      // Rounding can push the region 1px past the edge; pull it back in.
+      region.width = Math.min(region.width, W - region.left);
+      region.height = Math.min(region.height, H - region.top);
+    }
+
+    const out = await (region ? img.extract(region) : img)
+      .resize(size, size, { fit: "cover" })
+      .webp({ quality: 78 })
+      .toBuffer();
+
+    res.setHeader("Content-Type", "image/webp");
+    res.setHeader("Content-Length", out.byteLength);
+    res.setHeader("Cache-Control", "private, max-age=31536000, immutable");
+    return res.send(out);
+  } catch (error: any) {
+    return res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/faces/[faceId]/not-a-face.ts
+++ b/src/pages/api/face-review/faces/[faceId]/not-a-face.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { hideFace } from "@/lib/face-review/queries";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * Hide a detection that isn't a real face. PER-FACE only, on purpose: the
+ * source tool shipped (and removed) bulk variants after nearly firing them
+ * against real family data — a deliberate one-face click stays.
+ * Direct DB write (isVisible=false + detach), owner-scoped via the asset;
+ * the REST DELETE /faces/{id} alternative was never live-confirmed there.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const faceId = String(req.query.faceId || "");
+    if (!/^[0-9a-f-]{36}$/i.test(faceId)) {
+      return res.status(400).json({ error: "Invalid face id" });
+    }
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+
+    const hidden = await hideFace(faceId, gate.ownerId);
+    if (!hidden) return res.status(404).json({ error: "Face not found" });
+    return res.status(200).json({ ok: true });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/faces/reassign.ts
+++ b/src/pages/api/face-review/faces/reassign.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { parseFaceIds, reassignFaces, resolveTarget } from "@/lib/face-review/actions";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * Reassign one or many faces to a person — the single write primitive behind
+ * per-face "This is actually …", the bulk bar, cluster confirms, and Find
+ * More's Apply. Body: { faceIds: string[], personId?: string, name?: string }
+ * (personId wins; a bare name resolves to an existing person or creates one).
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+
+    const faceIds = parseFaceIds(req.body);
+    if (!faceIds.length) return res.status(400).json({ error: "No faces given" });
+    if (!req.body?.personId && !(req.body?.name || "").trim()) {
+      return res.status(400).json({ error: "personId or name required" });
+    }
+
+    const target = await resolveTarget(gate.user, gate.ownerId, req.body);
+    const { done, failed } = await reassignFaces(gate.user, faceIds, target.id, gate.ownerId);
+    return res.status(200).json({ done, failed, personId: target.id });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/faces/stranger.ts
+++ b/src/pages/api/face-review/faces/stranger.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { parseFaceIds, reassignFaces } from "@/lib/face-review/actions";
+import { createPerson, strangerName } from "@/lib/face-review/immich";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * "I don't know this person" / "Same unknown person": split the given faces
+ * off to ONE new uniquely-named Stranger record. Fully reversible — the
+ * stranger can be reassigned or renamed any time. There is deliberately no
+ * unassign (Immich has no endpoint for it); a fresh person is the mechanism.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+
+    const faceIds = parseFaceIds(req.body);
+    if (!faceIds.length) return res.status(400).json({ error: "No faces given" });
+
+    const name = strangerName();
+    const person = await createPerson(gate.user, name);
+    const { done, failed } = await reassignFaces(gate.user, faceIds, person.id, gate.ownerId);
+    return res.status(200).json({ done, failed, personId: person.id, name });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/job-status.ts
+++ b/src/pages/api/face-review/job-status.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getJobStatus } from "@/lib/face-review/immich";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/** Facial-recognition job queue snapshot (for the scan progress pill). */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+    const status = await getJobStatus(gate.user);
+    return res.status(200).json(status?.facialRecognition ?? {});
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/names.ts
+++ b/src/pages/api/face-review/names.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getNamedPeople } from "@/lib/face-review/queries";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/** Autocomplete source: the owner's real-named people (no Strangers). */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+    const names = await getNamedPeople(gate.ownerId);
+    return res.status(200).json(names);
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/candidate-clusters.ts
+++ b/src/pages/api/face-review/people/[id]/candidate-clusters.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getCandidateClusters } from "@/lib/face-review/queries";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+import { IFaceReviewScope } from "@/types/faceReview";
+
+/**
+ * Cluster the candidate pool (closest ~2000 non-member faces) by mutual
+ * similarity — a missed relative shows up as one group instead of dozens of
+ * separate Yes/No cards. POST for the same reason as /candidates: the body
+ * carries the reject list. threshold IS reviewer-adjustable here (unlike
+ * own-face clusters) — loosening genuinely helps on a candidate pool.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const { ownerId, personId } = gate;
+
+    const body = req.body || {};
+    const scope: IFaceReviewScope = body.scope === "named" ? "named" : "unnamed";
+    const excludeIds: string[] = Array.isArray(body.exclude)
+      ? body.exclude.filter((x: unknown) => typeof x === "string" && /^[0-9a-f-]{36}$/i.test(x))
+      : [];
+    let threshold = parseFloat(String(body.threshold ?? "")) || 0.65;
+    threshold = Math.min(Math.max(threshold, 0.3), 0.95);
+
+    const result = await getCandidateClusters(personId, ownerId, { scope, excludeIds, threshold });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/candidates.ts
+++ b/src/pages/api/face-review/people/[id]/candidates.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getCandidateFaces } from "@/lib/face-review/queries";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+import { IFaceReviewScope } from "@/types/faceReview";
+
+/**
+ * "Find more of this person" feed. POST because the body carries the
+ * reviewer's browser-local reject list (exclude[]) — those faces were
+ * already judged "not them" on this device and must not reappear.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const { ownerId, personId } = gate;
+
+    const body = req.body || {};
+    const scope: IFaceReviewScope = body.scope === "named" ? "named" : "unnamed";
+    const excludeIds: string[] = Array.isArray(body.exclude)
+      ? body.exclude.filter((x: unknown) => typeof x === "string" && /^[0-9a-f-]{36}$/i.test(x))
+      : [];
+    const limit = Math.min(Math.max(1, +body.limit || 24), 100);
+    const offset = Math.max(0, +body.offset || 0);
+
+    const result = await getCandidateFaces(personId, ownerId, { scope, excludeIds, limit, offset });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/clusters.ts
+++ b/src/pages/api/face-review/people/[id]/clusters.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getPersonClusters } from "@/lib/face-review/queries";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+
+/**
+ * Own-face clusters: mutual-similarity groups inside one person's tagged
+ * faces (single-linkage over cosine similarity; see lib/face-review/cluster).
+ * threshold is accepted but the UI pins the default — kept for parity with
+ * the source tool's API and future tuning.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const { ownerId, personId } = gate;
+
+    let threshold = parseFloat(String(req.query.threshold ?? "")) || 0.65;
+    threshold = Math.min(Math.max(threshold, 0.3), 0.95);
+
+    const result = await getPersonClusters(personId, ownerId, { threshold });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    // The maxFaces ceiling throws — surface it as a client-visible 400.
+    const status = /Too many faces/.test(error?.message || "") ? 400 : 500;
+    res.status(status).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/faces.ts
+++ b/src/pages/api/face-review/people/[id]/faces.ts
@@ -1,0 +1,60 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getPersonMeta, getRankedFaces, IRankedSort } from "@/lib/face-review/queries";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+
+const SORTS: IRankedSort[] = ["confidence", "recent", "oldest"];
+const PER_PAGE = [25, 50, 100, 200];
+
+/** Tagged Faces grid: a person's own faces, least-typical-first by default. */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const { ownerId, personId } = gate;
+
+    const sort = SORTS.includes(req.query.sort as IRankedSort)
+      ? (req.query.sort as IRankedSort)
+      : "confidence";
+    const perPage = PER_PAGE.includes(+(req.query.perPage as string))
+      ? +(req.query.perPage as string)
+      : 50;
+    const prebirthOnly = req.query.show === "prebirth";
+    let page = Math.max(1, +(req.query.page as string) || 1);
+
+    const meta = await getPersonMeta(personId, ownerId);
+    if (prebirthOnly && !meta?.birthDate) {
+      return res.status(200).json({
+        faces: [], total: 0, page: 1, perPage,
+        personName: meta?.name ?? "", birthDate: null,
+      });
+    }
+
+    let result = await getRankedFaces(personId, ownerId, {
+      page, perPage,
+      // Pre-birth review is always least-typical-first, like the source tool.
+      sort: prebirthOnly ? "confidence" : sort,
+      prebirthOnly,
+    });
+    // Clamp out-of-range pages (e.g. a bulk action emptied the last page and
+    // the client re-fetched the same page number) to the real last page.
+    if (!result.faces.length && page > 1) {
+      const probe = await getRankedFaces(personId, ownerId, { page: 1, perPage, sort, prebirthOnly });
+      const lastPage = Math.max(1, Math.ceil(probe.total / perPage));
+      if (page > lastPage) {
+        page = lastPage;
+        result = page === 1 ? probe : await getRankedFaces(personId, ownerId, { page, perPage, sort, prebirthOnly });
+      }
+    }
+
+    return res.status(200).json({
+      ...result,
+      page,
+      perPage,
+      personName: meta?.name ?? "",
+      birthDate: meta?.birthDate ?? null,
+    });
+  } catch (error: any) {
+    res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/info.ts
+++ b/src/pages/api/face-review/people/[id]/info.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getPersonMeta } from "@/lib/face-review/queries";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+
+/** Review-page header data. Owner-gated (unlike the legacy people/[id]/info). */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const meta = await getPersonMeta(gate.personId, gate.ownerId);
+    if (!meta) return res.status(404).json({ error: "Person not found" });
+    return res.status(200).json({ id: gate.personId, ...meta });
+  } catch (error: any) {
+    res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/reassign-all.ts
+++ b/src/pages/api/face-review/people/[id]/reassign-all.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { ensurePersonThumbnail, resolveTarget } from "@/lib/face-review/actions";
+import { mergePerson } from "@/lib/face-review/immich";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+
+/**
+ * "This whole person is actually X": merge this person into the target.
+ * Merging into an EXISTING person is destructive-adjacent (their face sets
+ * combine), so it two-steps: without confirmMerge the route answers 409
+ * { needsConfirm: true } and the client asks the human first.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+
+    const body = req.body || {};
+    if (!body.personId && !(body.name || "").trim()) {
+      return res.status(400).json({ error: "personId or name required" });
+    }
+
+    const target = await resolveTarget(gate.user, gate.ownerId, body);
+    if (target.id === gate.personId) {
+      return res.status(400).json({ error: "That's already this person." });
+    }
+    if (target.matchedExisting && !body.confirmMerge) {
+      return res.status(409).json({
+        needsConfirm: true,
+        message: "Target already exists. Merge this person into them?",
+      });
+    }
+    await mergePerson(gate.user, target.id, [gate.personId]);
+    await ensurePersonThumbnail(gate.user, target.id, gate.ownerId).catch(() => {});
+    return res.status(200).json({ mergedInto: target.id });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/[id]/stranger-all.ts
+++ b/src/pages/api/face-review/people/[id]/stranger-all.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { strangerName, updatePersonName } from "@/lib/face-review/immich";
+import { requireOwnedPerson } from "@/lib/face-review/route-utils";
+
+/**
+ * "I don't know this person" for the WHOLE person: a plain rename to a
+ * unique Stranger label. Keeps the cluster intact and fully reversible —
+ * nothing moves, only the name changes.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireOwnedPerson(req, res);
+    if (!gate) return;
+    const name = strangerName();
+    await updatePersonName(gate.user, gate.personId, name);
+    return res.status(200).json({ name });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/people/index.ts
+++ b/src/pages/api/face-review/people/index.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getPeopleWithCounts, IFaceReviewPeopleFilter } from "@/lib/face-review/queries";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+const FILTERS: IFaceReviewPeopleFilter[] = ["all", "named", "unnamed", "strangers", "hidden", "prebirth"];
+
+/** Face Review landing grid: this owner's people with visible-face counts. */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+
+    const filter = FILTERS.includes(req.query.filter as IFaceReviewPeopleFilter)
+      ? (req.query.filter as IFaceReviewPeopleFilter)
+      : "named";
+
+    const people = await getPeopleWithCounts(gate.ownerId, filter);
+    return res.status(200).json({ people, total: people.length });
+  } catch (error: any) {
+    res.status(500).json({ error: error?.message });
+  }
+}

--- a/src/pages/api/face-review/scan-missing.ts
+++ b/src/pages/api/face-review/scan-missing.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getJobStatus, runFacialRecognitionMissing } from "@/lib/face-review/immich";
+import { requireUser } from "@/lib/face-review/route-utils";
+
+/**
+ * Queue Facial Recognition in MISSING mode (assign unprocessed faces without
+ * re-clustering everything — "All" can overwrite manual corrections).
+ * Returns the job snapshot so the UI can show queue depth.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  try {
+    const gate = await requireUser(req, res);
+    if (!gate) return;
+    await runFacialRecognitionMissing(gate.user);
+    const status = await getJobStatus(gate.user);
+    return res.status(200).json({
+      queuedAt: new Date().toISOString(),
+      facialRecognition: status?.facialRecognition ?? {},
+    });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message });
+  }
+}

--- a/src/pages/face-review/[personId].tsx
+++ b/src/pages/face-review/[personId].tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import Image from "next/image";
+import { useRouter } from "next/router";
+
+import { CandidateClustersView, OwnClustersView } from "@/components/face-review/ClusterViews";
+import FindMoreFacesView from "@/components/face-review/FindMoreFacesView";
+import { IPrimaryTab, ISubTab } from "@/components/face-review/ReviewTabs";
+import TaggedFacesView from "@/components/face-review/TaggedFacesView";
+import PageLayout from "@/components/layouts/PageLayout";
+import Header from "@/components/shared/Header";
+import Loader from "@/components/ui/loader";
+import { PERSON_THUBNAIL_PATH } from "@/config/routes";
+import { getFaceReviewPersonInfo } from "@/handlers/api/faceReview.handler";
+import { IFaceReviewScope } from "@/types/faceReview";
+
+/**
+ * Face Review page: 2 primary tabs (which face set) x 2 sub-tabs (which lens
+ * on it) — Tagged faces = this person's own detections; Find more =
+ * candidates near their centroid that aren't them yet. Faces = flat ranked
+ * list; Clusters = mutual-similarity groups.
+ */
+export default function FaceReviewPersonPage() {
+  const router = useRouter();
+  const { personId } = router.query as { personId: string };
+  const tab = (router.query.tab as IPrimaryTab) || "tagged";
+  const sub = (router.query.sub as ISubTab) || "faces";
+  const scope: IFaceReviewScope = router.query.scope === "named" ? "named" : "unnamed";
+  // Which list filter the user came from on the index page, so a whole-
+  // person merge can send them back to it instead of the default filter.
+  const returnFilter = typeof router.query.returnFilter === "string" ? router.query.returnFilter : undefined;
+
+  const info = useQuery({
+    queryKey: ["face-review", "info", personId],
+    queryFn: () => getFaceReviewPersonInfo(personId),
+    enabled: !!personId,
+  });
+
+  const setParams = (params: Record<string, string>) => {
+    router.push(
+      { pathname: router.pathname, query: { ...router.query, ...params } },
+      undefined,
+      { shallow: true }
+    );
+  };
+
+  if (!personId || info.isLoading) return <Loader />;
+  if (info.isError) {
+    return (
+      <PageLayout title="Face Review">
+        <div className="p-8 text-center text-destructive">
+          {String((info.error as any)?.error || "Person not found")}
+        </div>
+      </PageLayout>
+    );
+  }
+  const person = info.data;
+
+  return (
+    <PageLayout className="!p-4" title={`Review: ${person?.name || "(unnamed)"}`}>
+      <Header
+        leftComponent={
+          <div className="flex items-center gap-2">
+            <Image
+              src={PERSON_THUBNAIL_PATH(personId)}
+              alt={person?.name || "person"}
+              width={32}
+              height={32}
+              className="rounded-full"
+              unoptimized
+            />
+            <span className="font-medium">Reviewing: {person?.name || "(unnamed)"}</span>
+            <span className="text-sm text-muted-foreground">
+              {person?.faceCount?.toLocaleString?.() ?? person?.faceCount} faces
+            </span>
+          </div>
+        }
+      />
+      <div className="flex flex-col gap-4 px-4 pb-8">
+        {/* Each view renders the tab bar (via <ReviewTabs/>) inline with its
+            own controls, so the whole header sits on one row. */}
+        {tab === "tagged" && sub === "faces" && (
+          <TaggedFacesView
+            personId={personId}
+            personName={person?.name || ""}
+            tab={tab} sub={sub} scope={scope} setParams={setParams}
+            returnFilter={returnFilter}
+          />
+        )}
+        {tab === "tagged" && sub === "clusters" && (
+          <OwnClustersView
+            personId={personId}
+            tab={tab} sub={sub} scope={scope} setParams={setParams}
+          />
+        )}
+        {tab === "find-more" && sub === "faces" && (
+          <FindMoreFacesView
+            personId={personId}
+            personName={person?.name || ""}
+            tab={tab} sub={sub} scope={scope} setParams={setParams}
+          />
+        )}
+        {tab === "find-more" && sub === "clusters" && (
+          <CandidateClustersView
+            personId={personId}
+            personName={person?.name || ""}
+            tab={tab} sub={sub} scope={scope} setParams={setParams}
+          />
+        )}
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/pages/face-review/index.tsx
+++ b/src/pages/face-review/index.tsx
@@ -1,0 +1,306 @@
+import React, { useMemo, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { CheckCircle2, Loader2, ScanFace, Trash2, X } from "lucide-react";
+import toast from "react-hot-toast";
+
+import PageLayout from "@/components/layouts/PageLayout";
+import Header from "@/components/shared/Header";
+import { AlertDialog } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { useCurrentUser } from "@/contexts/CurrentUserContext";
+import { PERSON_THUBNAIL_PATH } from "@/config/routes";
+import {
+  clearEmptyPeople, getScanStatus, listFaceReviewPeople, scanMissing,
+} from "@/handlers/api/faceReview.handler";
+import { IFaceReviewPerson } from "@/types/faceReview";
+
+const FILTERS = [
+  { value: "named", label: "Named people" },
+  { value: "unnamed", label: "Unnamed only" },
+  { value: "strangers", label: "Strangers (split-offs)" },
+  { value: "prebirth", label: "Pre-birth faces" },
+  { value: "hidden", label: "Hidden" },
+  { value: "all", label: "All" },
+];
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Faces still queued/processing in the facial-recognition job. */
+const remainingFrom = (jc: Record<string, number> = {}) =>
+  (jc.active || 0) + (jc.waiting || 0) + (jc.delayed || 0) + (jc.paused || 0);
+
+type IScan =
+  | { phase: "idle" }
+  | { phase: "running"; remaining: number }
+  | { phase: "done"; total: number; gainers: { name: string; delta: number }[] };
+
+/**
+ * Face Review landing: pick a person to review. Deliberately NOT another
+ * people browser (Manage People already exists) — this grid is ordered by
+ * face count because more faces = more room for misassignments.
+ */
+const FILTER_VALUES = FILTERS.map((f) => f.value);
+
+export default function FaceReviewIndexPage() {
+  const router = useRouter();
+  const { isAdmin } = useCurrentUser();
+  const queryClient = useQueryClient();
+  // Kept in the URL (not plain useState) so a refresh, or navigating back
+  // from a person's review page, lands on the same filter instead of always
+  // resetting to "Named people".
+  const rawFilter = router.query.filter;
+  const filter = typeof rawFilter === "string" && FILTER_VALUES.includes(rawFilter) ? rawFilter : "named";
+  const setFilter = (v: string) => {
+    router.push({ pathname: router.pathname, query: { ...router.query, filter: v } }, undefined, { shallow: true });
+  };
+  const [search, setSearch] = useState("");
+  const [busy, setBusy] = useState<null | "scan" | "clear">(null);
+  const [scan, setScan] = useState<IScan>({ phase: "idle" });
+  const cancelledRef = useRef(false);
+  React.useEffect(() => () => { cancelledRef.current = true; }, []);
+
+  const query = useQuery({
+    queryKey: ["face-review", "people", filter],
+    queryFn: () => listFaceReviewPeople(filter),
+  });
+
+  /**
+   * #2: snapshot this owner's face counts, queue the (instance-wide) Missing
+   * recognition job, poll the queue until it drains, then diff the counts to
+   * show exactly which people gained faces. The job can take a while on a big
+   * library, so the pill is non-blocking — the user can keep reviewing.
+   */
+  const runScan = async () => {
+    setBusy("scan");
+    setScan({ phase: "running", remaining: 0 });
+    try {
+      const before = await listFaceReviewPeople("all");
+      const beforeById = new Map<string, number>(
+        (before.people ?? []).map((p: IFaceReviewPerson) => [p.id, p.faceCount])
+      );
+
+      await scanMissing();
+
+      // Poll until the queue is idle. Break as soon as a job we saw running
+      // drains; if the job never showed work (nothing to process), give it a
+      // short grace window instead of waiting forever. Hard cap at 20 min.
+      let sawActivity = false;
+      let idlePolls = 0;
+      const startedAt = Date.now();
+      const MAX_MS = 20 * 60 * 1000;
+      while (!cancelledRef.current) {
+        await sleep(2500);
+        if (cancelledRef.current) return;
+        let remaining = 0;
+        try {
+          const status = await getScanStatus();
+          remaining = remainingFrom(status.jobCounts);
+        } catch {
+          // transient — treat as idle-ish, keep polling within the cap
+        }
+        setScan((s) => (s.phase === "running" ? { phase: "running", remaining } : s));
+        if (remaining > 0) { sawActivity = true; idlePolls = 0; }
+        else idlePolls += 1;
+        const done = (sawActivity && remaining === 0) || (!sawActivity && idlePolls >= 4);
+        if (done || Date.now() - startedAt > MAX_MS) break;
+      }
+      if (cancelledRef.current) return;
+
+      const after = await listFaceReviewPeople("all");
+      const gainers = (after.people ?? [])
+        .map((p: IFaceReviewPerson) => ({ name: p.name || "(unnamed)", delta: p.faceCount - (beforeById.get(p.id) ?? 0) }))
+        .filter((g: { delta: number }) => g.delta > 0)
+        .sort((a: { delta: number }, b: { delta: number }) => b.delta - a.delta);
+      const total = gainers.reduce((sum: number, g: { delta: number }) => sum + g.delta, 0);
+
+      setScan({ phase: "done", total, gainers });
+      queryClient.invalidateQueries({ queryKey: ["face-review", "people"] });
+    } catch (e: any) {
+      setScan({ phase: "idle" });
+      toast.error(`Scan failed: ${e?.error || e?.message || "unknown"}`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const runClear = async () => {
+    setBusy("clear");
+    try {
+      const res = await clearEmptyPeople();
+      toast.success(`Deleted ${res.deleted} empty ${res.deleted === 1 ? "person" : "people"}`);
+      queryClient.invalidateQueries({ queryKey: ["face-review", "people"] });
+    } catch (e: any) {
+      toast.error(`Failed: ${e?.error || e?.message || "unknown"}`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const allPeople: IFaceReviewPerson[] = query.data?.people ?? [];
+  const q = search.trim().toLowerCase();
+  const people = useMemo(
+    () => (q ? allPeople.filter((p) => (p.name || "").toLowerCase().includes(q)) : allPeople),
+    [allPeople, q]
+  );
+
+  return (
+    <PageLayout title="Face Review">
+      <Header
+        leftComponent="Face Review"
+        rightComponent={
+          <div className="flex items-center gap-2">
+            {/* Queues Immich's PUT /jobs/facialRecognition, which the server
+                gates admin: true — a non-admin's click would just 403. */}
+            {isAdmin && (
+              <AlertDialog
+                asChild
+                disabled={!!busy}
+                title="Run facial recognition on missing faces?"
+                description={'Queues Immich\'s Facial Recognition job in "Missing" mode: detected faces that aren\'t assigned to anyone yet get matched to your existing people. It never re-clusters existing assignments, so your manual corrections are safe. (The dangerous variant is "All", which this tool never uses.) When it finishes, you\'ll see how many faces were newly assigned and to whom.'}
+                onConfirm={runScan}
+              >
+                <Button size="sm" variant="outline" disabled={!!busy}>
+                  {busy === "scan" ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <ScanFace size={14} className="mr-1" />}
+                  Scan unassigned faces
+                </Button>
+              </AlertDialog>
+            )}
+            <AlertDialog
+              asChild
+              disabled={!!busy}
+              title="Delete empty person records?"
+              description="Removes YOUR person records that have zero visible faces — leftovers from failed or retried reassignments. People with any face at all are untouched, and other users' records are never affected."
+              onConfirm={runClear}
+            >
+              <Button size="sm" variant="outline" disabled={!!busy}>
+                {busy === "clear" ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <Trash2 size={14} className="mr-1" />}
+                Delete empty people
+              </Button>
+            </AlertDialog>
+          </div>
+        }
+      />
+      <div className="flex flex-col gap-4 p-4">
+        {scan.phase !== "idle" && (
+          <div className="flex items-start gap-3 rounded-lg border border-primary bg-card px-4 py-3 text-sm">
+            {scan.phase === "running" ? (
+              <>
+                <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-primary" />
+                <div>
+                  <div className="font-medium">Recognising unassigned faces…</div>
+                  <div className="text-muted-foreground">
+                    {scan.remaining > 0
+                      ? `${scan.remaining.toLocaleString()} face${scan.remaining === 1 ? "" : "s"} left in the queue.`
+                      : "Waiting for the job to settle."}{" "}
+                    You can keep reviewing while this runs.
+                  </div>
+                </div>
+              </>
+            ) : (
+              <>
+                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+                <div className="min-w-0 flex-1">
+                  {scan.total > 0 ? (
+                    <>
+                      <div className="font-medium">
+                        {scan.total.toLocaleString()} face{scan.total === 1 ? "" : "s"} newly assigned across{" "}
+                        {scan.gainers.length} {scan.gainers.length === 1 ? "person" : "people"}.
+                      </div>
+                      <div className="mt-1 flex flex-wrap gap-x-4 gap-y-0.5 text-muted-foreground">
+                        {scan.gainers.map((g) => (
+                          <span key={g.name}>{g.name} <span className="text-emerald-600">+{g.delta}</span></span>
+                        ))}
+                      </div>
+                    </>
+                  ) : (
+                    <div className="font-medium">
+                      No new faces were assigned to your people. Anything still unrecognised has no confident match yet.
+                    </div>
+                  )}
+                </div>
+                <button
+                  className="shrink-0 text-muted-foreground hover:text-foreground"
+                  aria-label="Dismiss"
+                  onClick={() => setScan({ phase: "idle" })}
+                >
+                  <X size={16} />
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="text-sm text-muted-foreground">Show</label>
+          <Select value={filter} onValueChange={setFilter}>
+            <SelectTrigger className="w-52 h-8"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {FILTERS.map((f) => (
+                <SelectItem key={f.value} value={f.value}>{f.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="relative">
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search by name…"
+              className="h-8 w-56 pr-7"
+            />
+            {search && (
+              <button
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label="Clear search"
+                onClick={() => setSearch("")}
+              >
+                <X size={14} />
+              </button>
+            )}
+          </div>
+          <span className="ml-auto text-sm text-muted-foreground">
+            {people.length}{q && ` of ${allPeople.length}`} {people.length === 1 ? "person" : "people"}
+          </span>
+        </div>
+        {query.isLoading ? (
+          <div className="flex justify-center py-16"><Loader2 className="animate-spin" /></div>
+        ) : !allPeople.length ? (
+          <div className="py-16 text-center text-muted-foreground">No people in this view.</div>
+        ) : !people.length ? (
+          <div className="py-16 text-center text-muted-foreground">No people match &ldquo;{search}&rdquo;.</div>
+        ) : (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-4">
+            {people.map((p) => (
+              <Link
+                key={p.id}
+                href={{ pathname: `/face-review/${p.id}`, query: { returnFilter: filter } }}
+                className="flex flex-col items-center gap-2 rounded-xl border bg-card p-4 transition-colors hover:border-primary"
+              >
+                <Image
+                  src={PERSON_THUBNAIL_PATH(p.id)}
+                  alt={p.name || "(unnamed)"}
+                  width={96}
+                  height={96}
+                  className="h-24 w-24 rounded-full object-cover bg-muted"
+                  unoptimized
+                />
+                <span className="text-sm font-medium text-center leading-tight">
+                  {p.name || <span className="italic text-muted-foreground">(unnamed)</span>}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {p.faceCount.toLocaleString()} face{p.faceCount === 1 ? "" : "s"}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/pages/face-review/index.tsx
+++ b/src/pages/face-review/index.tsx
@@ -240,7 +240,7 @@ export default function FaceReviewIndexPage() {
         <div className="flex flex-wrap items-center gap-2">
           <label className="text-sm text-muted-foreground">Show</label>
           <Select value={filter} onValueChange={setFilter}>
-            <SelectTrigger className="w-52 h-8"><SelectValue /></SelectTrigger>
+            <SelectTrigger className="w-52 h-9"><SelectValue /></SelectTrigger>
             <SelectContent>
               {FILTERS.map((f) => (
                 <SelectItem key={f.value} value={f.value}>{f.label}</SelectItem>
@@ -252,7 +252,7 @@ export default function FaceReviewIndexPage() {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search by name…"
-              className="h-8 w-56 pr-7"
+              className="h-9 w-56 pr-7"
             />
             {search && (
               <button

--- a/src/types/faceReview.ts
+++ b/src/types/faceReview.ts
@@ -1,0 +1,64 @@
+export interface IFaceReviewFace {
+  faceId: string;
+  assetId: string;
+  /** Cosine distance to the person's centroid embedding. Higher = less
+   * typical for this person = more likely misassigned. Null when the face
+   * has no embedding row. */
+  distance: number | null;
+  /** ISO date (yyyy-mm-dd) the photo was taken, camera-local when known. */
+  takenAt: string | null;
+  boundingBoxX1: number;
+  boundingBoxY1: number;
+  boundingBoxX2: number;
+  boundingBoxY2: number;
+  imageWidth: number;
+  imageHeight: number;
+  /** Only on candidate faces: the person the face is currently assigned to. */
+  curPersonId?: string | null;
+  curName?: string | null;
+}
+
+export interface IFaceCluster {
+  /** 1-based display index, assigned after sorting. */
+  index: number;
+  size: number;
+  /** Mean distance-to-centroid of the cluster's faces (candidate clusters
+   * are sorted by this ascending — most-likely-the-person first). */
+  meanDistance: number | null;
+  faces: IFaceReviewFace[];
+}
+
+export interface IRankedFacesResponse {
+  faces: IFaceReviewFace[];
+  total: number;
+  page: number;
+  perPage: number;
+  personName: string;
+  birthDate: string | null;
+}
+
+export interface IClustersResponse {
+  clusters: IFaceCluster[];
+  singletonCount: number;
+  threshold: number;
+  totalFaces: number;
+}
+
+export interface ICandidatesResponse {
+  candidates: IFaceReviewFace[];
+  hasNext: boolean;
+}
+
+export interface ICandidateClustersResponse extends IClustersResponse {
+  poolSize: number;
+}
+
+export type IFaceReviewScope = "unnamed" | "named";
+
+export interface IFaceReviewPerson {
+  id: string;
+  name: string;
+  birthDate: string | null;
+  isHidden: boolean;
+  faceCount: number;
+}


### PR DESCRIPTION
**Part 4 of 4** of the Face Review tool. **Stacked on #311** (write layer,
itself on #310 → #309). Until those merge, the diff here includes all four
parts. Review order: #309 → #310 → #311 → this.

## What this adds

The Face Review front end (sidebar: Tools → Face Review):
- A people landing grid (count-sorted, filterable) at `/face-review`, and a
  per-person review page at `/face-review/[personId]`.
- The review page has two primary tabs — the person's **own faces** and
  **candidate faces** (close to the centroid but not assigned) — each with a
  **Faces** sub-tab (ranked, per-face + bulk actions) and a **Clusters**
  sub-tab (the #309 engine grouping, to catch a wrongly-merged or missed
  person as one group instead of many one-off decisions).
- Face crops, a lightbox, an inline person-name autocomplete, bulk-select
  with shift-range, and confirm dialogs on the destructive actions.
- "Scan Unassigned Faces" is hidden for non-admins (Immich requires admin for
  the facial-recognition job).

This part wires the components/pages to the read (#310) and write (#311) APIs
and adds the sidebar entry.

## Testing
`tsc --noEmit` clean. Exercised in-browser on a live ~26k-asset / 15-user
instance: landing grid, all four tabs (crops render, distance pills match API
values), shift-click range, and the confirm flows.
