### PR TITLE
fix(workflows): geo_radius matched a square, not a circle

### DIFF
--- a/src/lib/workflow/conditionBuilder.ts
+++ b/src/lib/workflow/conditionBuilder.ts
@@ -231,19 +231,44 @@ function buildSingleCondition(c: ICondition): SQL | undefined {
     case "not_in_specific_album":
       return sql`NOT EXISTS (SELECT 1 FROM "album_asset" aa WHERE aa."assetId" = ${assets.id} AND aa."albumId" = ${c.albumId})`;
 
-    case "geo_radius":
-      if (c.lat !== undefined && c.lng !== undefined && c.radiusKm) {
-        // Haversine approximation: 1 degree ≈ 111km
-        const latDelta = c.radiusKm / 111;
-        const lngDelta = c.radiusKm / (111 * Math.cos((c.lat * Math.PI) / 180));
-        return and(
-          gte(exif.latitude, c.lat - latDelta),
-          lte(exif.latitude, c.lat + latDelta),
-          gte(exif.longitude, c.lng - lngDelta),
-          lte(exif.longitude, c.lng + lngDelta),
-        )!;
+    case "geo_radius": {
+      const lat = Number(c.lat);
+      const lng = Number(c.lng);
+      const r = Number(c.radiusKm);
+      if (![lat, lng, r].every(Number.isFinite) || r <= 0) return undefined;
+
+      // Exact great-circle (haversine) distance in km. Despite the old
+      // comment, the previous implementation was only the bounding box
+      // below — a square, whose corners reach ~1.41x the requested radius.
+      const distanceKm = sql`(2 * 6371 * asin(sqrt(
+        power(sin(radians(${exif.latitude} - ${lat}) / 2), 2) +
+        cos(radians(${lat})) * cos(radians(${exif.latitude})) *
+        power(sin(radians(${exif.longitude} - ${lng}) / 2), 2)
+      )))`;
+
+      // The box is kept as a cheap, index-friendly pre-filter that the exact
+      // distance then trims to a true circle. It's skipped near the poles and
+      // the antimeridian, where a naive box wraps and would drop real matches.
+      const latDelta = r / 111.045;
+      const cosLat = Math.cos((lat * Math.PI) / 180);
+      const lngDelta = Math.abs(cosLat) < 1e-6 ? 180 : r / (111.045 * Math.abs(cosLat));
+      const boxSafe =
+        lngDelta < 180 &&
+        lng - lngDelta >= -180 && lng + lngDelta <= 180 &&
+        lat - latDelta >= -90 && lat + latDelta <= 90;
+
+      const parts: SQL[] = [];
+      if (boxSafe) {
+        parts.push(
+          gte(exif.latitude, lat - latDelta),
+          lte(exif.latitude, lat + latDelta),
+          gte(exif.longitude, lng - lngDelta),
+          lte(exif.longitude, lng + lngDelta),
+        );
       }
-      return undefined;
+      parts.push(sql`${distanceKm} <= ${r}`);
+      return and(...parts)!;
+    }
 
     default:
       return undefined;


### PR DESCRIPTION
### The bug

`geo_radius` carries a `// Haversine approximation` comment, but the code only ever built a lat/lng **bounding box**. A box's corners sit up to ~1.41× the requested radius from the centre, so the condition matches photos that were never within the distance the user asked for.

```ts
// Haversine approximation: 1 degree ≈ 111km
const latDelta = c.radiusKm / 111;
const lngDelta = c.radiusKm / (111 * Math.cos((c.lat * Math.PI) / 180));
return and(
  gte(exif.latitude,  c.lat - latDelta), lte(exif.latitude,  c.lat + latDelta),
  gte(exif.longitude, c.lng - lngDelta), lte(exif.longitude, c.lng + lngDelta),
)!;
```

### Measured impact

Run against a real library, 50 km radius around Edmonton:

| query | photos |
|---|---|
| bounding box only (current behaviour) | **62,506** |
| box + haversine (this PR) | **56,163** |
| haversine only | **56,163** |

**6,343 false positives**, the farthest **69.7 km** out on a 50 km request.

Note the second and third rows agree **exactly**. That's the useful part: it confirms the box is a strict superset of the circle, so it's safe to keep as a cheap, index-friendly pre-filter and let the exact distance trim the corners. No index-only scan is lost.

### The fix

- Exact great-circle distance (`2 * 6371 * asin(sqrt(...))`) applied on top of the existing box.
- The box is **skipped** near the poles and the antimeridian, where a naive box wraps and would drop real matches — there the distance check stands alone rather than returning wrong results.
- Guard tightened to `Number.isFinite` with `radius > 0`, so `NaN` no longer reaches the query builder. (`c.radiusKm` was previously truthy-checked, and `c.lat`/`c.lng` only `!== undefined`.)

### Verification

- Haversine checked against a known pair — Edmonton → Calgary returns **280.9 km** (real distance ~280 km) — and a zero-distance identity (**0.0000**).
- `tsc --noEmit` shows no new errors versus the `prerelease` baseline.
- Behaviour is otherwise unchanged: this stays inside-only and photos without GPS still match nothing.

Scoped deliberately to the bug — no new options or condition types.
