### PR TITLE
fix(workflows): stop storing every asset id in workflow_runs.result

### DIFF
--- a/src/lib/workflow/engine.ts
+++ b/src/lib/workflow/engine.ts
@@ -11,6 +11,12 @@ import { randomUUID } from "crypto";
 
 const PREFIX = "[Workflow]";
 
+// The run result is stored as JSON in workflow_runs.result and only ever used
+// to show thumbnails (max 50 in any view) plus a total count. Persisting every
+// processed asset id made this column reach ~1.6MB/run; store a small sample
+// plus an explicit total instead.
+const RESULT_ASSET_SAMPLE = 50;
+
 function log(runId: string, ...args: any[]) {
   console.log(`${PREFIX} [run:${runId.slice(0, 8)}]`, ...args);
 }
@@ -188,6 +194,7 @@ interface DebugStep {
 
 interface RunResult {
   matchedAssets: number;
+  assetCount: number;
   assetIds: string[];
   actions: any[];
   debug?: DebugStep[];
@@ -241,7 +248,7 @@ export async function executeWorkflow(
 
     log(runId, `Found ${triggerNodes.length} trigger node(s): ${triggerNodes.map(n => n.subType).join(", ")}`);
 
-    const result: RunResult = { matchedAssets: 0, assetIds: [], actions: [] };
+    const result: RunResult = { matchedAssets: 0, assetCount: 0, assetIds: [], actions: [] };
     const debugSteps: DebugStep[] = [];
     const allProcessedAssetIds = new Set<string>();
 
@@ -267,7 +274,7 @@ export async function executeWorkflow(
         label: `Asset Trigger: ${triggerNode.subType}`,
         inputAssets: 0,
         outputAssets: { out: assetIds.length },
-        assetIds: assetIds.slice(0, 100),
+        assetIds: assetIds.slice(0, RESULT_ASSET_SAMPLE),
         detail: `Lookback: ${lookback}m, Found ${assetIds.length} assets`,
       });
 
@@ -321,7 +328,7 @@ export async function executeWorkflow(
             label: `IF (${conditions.length} conditions)`,
             inputAssets: assetIds?.length || 0,
             outputAssets: { true: trueIds.length, false: falseIds.length },
-            assetIds: trueIds.slice(0, 100),
+            assetIds: trueIds.slice(0, RESULT_ASSET_SAMPLE),
             detail: `Matched: ${trueIds.length} true, ${falseIds.length} false`,
           });
 
@@ -396,14 +403,14 @@ export async function executeWorkflow(
           label: `Action: ${node.subType}`,
           inputAssets: actionAssetIds.length,
           outputAssets: {},
-          assetIds: actionAssetIds.slice(0, 100),
+          assetIds: actionAssetIds.slice(0, RESULT_ASSET_SAMPLE),
           detail: isDebug ? `DRY RUN — would process ${actionAssetIds.length} assets` : `Processing ${actionAssetIds.length} assets`,
         });
 
         if (!isDebug && actionAssetIds.length > 0) {
           const actionResult = await executeAction(node.subType, config, actionAssetIds, user);
           log(runId, `ACTION [${node.subType}] completed: ${actionResult.assetsProcessed} processed${actionResult.albumName ? ` → "${actionResult.albumName}"` : ""}${actionResult.error ? ` ERROR: ${actionResult.error}` : ""}`);
-          result.actions.push({ ...actionResult, assetIds: actionAssetIds });
+          result.actions.push({ ...actionResult, assetIds: actionAssetIds.slice(0, RESULT_ASSET_SAMPLE) });
 
           // Record processed assets to prevent reprocessing
           if (actionAssetIds.length > 0) {
@@ -424,9 +431,11 @@ export async function executeWorkflow(
       }
     }
 
-    // Finalize result
-    result.assetIds = Array.from(allProcessedAssetIds);
-    result.matchedAssets = result.assetIds.length;
+    // Finalize result — keep the full count but only a sample of the ids.
+    const allProcessedIds = Array.from(allProcessedAssetIds);
+    result.assetCount = allProcessedIds.length;
+    result.assetIds = allProcessedIds.slice(0, RESULT_ASSET_SAMPLE);
+    result.matchedAssets = allProcessedIds.length;
     result.debug = debugSteps;
 
     // Update run record

--- a/src/pages/api/workflows/index.ts
+++ b/src/pages/api/workflows/index.ts
@@ -23,12 +23,30 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .from(workflowNodes)
         .where(eq(workflowNodes.workflowId, w.id));
 
-      const [lastRun] = await appDb
-        .select()
+      const [lastRunRow] = await appDb
+        .select({
+          id: workflowRuns.id,
+          workflowId: workflowRuns.workflowId,
+          trigger: workflowRuns.trigger,
+          status: workflowRuns.status,
+          error: workflowRuns.error,
+          startedAt: workflowRuns.startedAt,
+          completedAt: workflowRuns.completedAt,
+          result: workflowRuns.result,
+        })
         .from(workflowRuns)
         .where(eq(workflowRuns.workflowId, w.id))
         .orderBy(desc(workflowRuns.startedAt))
         .limit(1);
+
+      // The list view only shows the processed-asset count, so strip the rest
+      // of the result JSON before sending it to the client.
+      let lastRun = lastRunRow || null;
+      if (lastRun?.result) {
+        let matchedAssets = 0;
+        try { matchedAssets = JSON.parse(lastRun.result)?.matchedAssets ?? 0; } catch {}
+        lastRun = { ...lastRun, result: JSON.stringify({ matchedAssets }) };
+      }
 
       const [runCountRow] = await appDb
         .select({ count: count() })

--- a/src/pages/workflows/[id].tsx
+++ b/src/pages/workflows/[id].tsx
@@ -651,7 +651,7 @@ function WorkflowEditorInner() {
                           )}
                           {result.assetIds && result.assetIds.length > 0 && (
                             <div>
-                              <p className="text-[10px] font-medium text-muted-foreground mb-1">Assets ({result.assetIds.length}):</p>
+                              <p className="text-[10px] font-medium text-muted-foreground mb-1">Assets ({result.assetCount ?? result.assetIds.length}):</p>
                               <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
                                 {result.assetIds.slice(0, 50).map((assetId: string) => (
                                   <img
@@ -661,8 +661,8 @@ function WorkflowEditorInner() {
                                     className="h-8 w-8 rounded object-cover"
                                   />
                                 ))}
-                                {result.assetIds.length > 50 && (
-                                  <span className="text-[10px] text-muted-foreground self-center">+{result.assetIds.length - 50} more</span>
+                                {(result.assetCount ?? result.assetIds.length) > 50 && (
+                                  <span className="text-[10px] text-muted-foreground self-center">+{(result.assetCount ?? result.assetIds.length) - 50} more</span>
                                 )}
                               </div>
                             </div>


### PR DESCRIPTION
### The problem

Every workflow run persists `result.assetIds` — **every** processed asset id — plus a second full copy inside `result.actions[].assetIds`, as JSON in `workflow_runs.result`. On a ~26k-asset library that's ~1.6 MB per run. The run view never displays more than a 50-thumbnail sample plus a total count, so the full id lists are pure ballast that grows the column without bound (in my install, 885 runs had grown it past a gigabyte in an 885-row table).

### The fix

Store only a small sample plus an explicit count:

- **engine**: cap `result.assetIds`, `result.actions[].assetIds`, and the debug step samples at `RESULT_ASSET_SAMPLE` (50); add `result.assetCount` for the true total (`matchedAssets` already carried it — `assetCount` makes the intent explicit for the ids list).
- **`workflows/[id].tsx`**: read the count from `assetCount`, falling back to `assetIds.length` for runs recorded before this change.
- **`api/workflows` list endpoint**: it only needs the count, so it now selects explicit columns and returns a compact `{ matchedAssets }` rather than shipping the whole `result` blob to the browser for every workflow in the list.

### Compatibility

No schema change, so no migration. Existing oversized rows keep working — the run view reads the fallback count — and they shrink to the new shape the next time each workflow runs. Anyone wanting to reclaim the space immediately can backfill the sample + count and `VACUUM` (that took my `app.db` from 1.3 GB to 38 MB), but nothing forces it.

`tsc --noEmit` shows no new errors vs the `prerelease` baseline.
