### PR TITLE
perf: let browsers cache thumbnail-proxy responses

### DIFF
--- a/src/pages/api/immich-proxy/asset/thumbnail/[id].ts
+++ b/src/pages/api/immich-proxy/asset/thumbnail/[id].ts
@@ -43,6 +43,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Set the appropriate headers for the image response
     res.setHeader('Content-Type', response.headers.get('Content-Type') || 'image/png')
     res.setHeader('Content-Length', imageBuffer.byteLength)
+    // A given asset id + size renders the same pixels for practical purposes
+    // (thumbnails only change on a manual regenerate) — let browsers keep it
+    // a week instead of refetching on every page visit.
+    res.setHeader('Cache-Control', 'private, max-age=604800')
 
     // Send the image data
     res.send(Buffer.from(imageBuffer))

--- a/src/pages/api/immich-proxy/thumbnail/[id].ts
+++ b/src/pages/api/immich-proxy/thumbnail/[id].ts
@@ -44,6 +44,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Set the appropriate headers for the image response
     res.setHeader('Content-Type', response.headers.get('Content-Type') || 'image/png')
     res.setHeader('Content-Length', imageBuffer.byteLength)
+    // Person cover thumbnails can change (Immich re-picks the face), so cap
+    // the cache at a day rather than the asset proxy's week.
+    res.setHeader('Cache-Control', 'private, max-age=86400')
 
     // Send the image data
     res.send(Buffer.from(imageBuffer))


### PR DESCRIPTION
The two thumbnail proxy routes (`/api/immich-proxy/thumbnail/[id]` and `/api/immich-proxy/asset/thumbnail/[id]`) sent no `Cache-Control`, so every thumbnail was refetched from Immich through the proxy on each page visit — noticeable on grid-heavy pages.

Add per-route caching:

- **Asset thumbnails** — an assetId + size renders the same pixels until a manual regenerate, so browsers can hold it a week (`private, max-age=604800`).
- **Person cover thumbnails** — Immich re-picks the representative face over time, so a shorter cap (`private, max-age=86400`, one day).

Both are `private` so a shared/proxy cache never serves one user's thumbnails to another.

`tsc --noEmit` clean vs the `prerelease` baseline.