### PR TITLE
feat(people): hide hidden people by default in Manage People

### DIFF
--- a/src/components/people/PeopleFilters.tsx
+++ b/src/components/people/PeopleFilters.tsx
@@ -20,7 +20,9 @@ import { removeNullOrUndefinedProperties } from "@/helpers/data.helper";
 export function PeopleFilters() {
   const router = useRouter();
   const filters = usePeopleFilterContext();
-  const { updateContext, page, maximumAssetCount, type = "all", query = "", visibility = "all" } = filters;
+  // visibility defaults to "visible" to match PeopleList's initial state, so
+  // the dropdown reflects what's actually being shown rather than saying "All".
+  const { updateContext, page, maximumAssetCount, type = "all", query = "", visibility = "visible" } = filters;
 
   const handleChange = (data: Partial<IPersonListFilters>) => {
     // Any filter change other than an explicit page navigation must reset

--- a/src/components/people/PeopleList.tsx
+++ b/src/components/people/PeopleList.tsx
@@ -26,6 +26,9 @@ export default function PeopleList() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [cols, setCols] = useState<number>(6);
   const [filters, setFilters] = useState<IPersonListFilters>({
+    // Hidden people are hidden for a reason — don't surface them until asked.
+    // Listed before router.query so a ?visibility= in the URL still wins.
+    visibility: "visible",
     ...router.query,
     page: 1,
   });


### PR DESCRIPTION
Manage People listed hidden people alongside everyone else. Hidden people are hidden in Immich for a reason (strangers, bad crops), so surfacing them by default just adds noise to the review pass.

- `PeopleList` defaults its filter to `visibility: "visible"` (spread **before** `...router.query`, so a `?visibility=` in the URL still wins).
- `PeopleFilters` defaults the visibility dropdown to `"visible"` to match, so the control reflects what's actually being shown rather than reading "All".

"Hidden" and "All" remain one dropdown click (or one `?visibility=` link) away. `IPersonListFilters` already carries `visibility`, so this is defaults-only — no API change.

`tsc --noEmit` clean vs the `prerelease` baseline.