### PR TITLE
fix: center the floating action bar over the content, not the viewport

### DIFF
--- a/src/components/shared/FloatingBar.tsx
+++ b/src/components/shared/FloatingBar.tsx
@@ -8,7 +8,9 @@ interface FloatingBarProps {
 
 export default function FloatingBar({ children, className }: FloatingBarProps) {
   return (
-      <div className={clsx('fixed bottom-10 left-0 right-0 max-w-2xl mx-auto py-2 px-2 rounded-lg flex justify-between items-center bg-white dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800 border shadow-lg z-50', className)}>
+      // left offsets mirror RootLayout's sidebar columns (md:200px / lg:240px)
+      // so the bar centers over the content area, not the whole viewport.
+      <div className={clsx('fixed bottom-10 left-0 md:left-[200px] lg:left-[240px] right-0 max-w-2xl mx-auto py-2 px-2 rounded-lg flex justify-between items-center bg-white dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800 border shadow-lg z-50', className)}>
         {children}
       </div>
   )


### PR DESCRIPTION
`FloatingBar` is `fixed` with `left-0 right-0` + `max-w-2xl mx-auto`, so it centers on the whole viewport. Once the sidebar is visible that puts it visibly left-of-center over the actual content area.

Offset its left edge by the sidebar's width at each breakpoint — `md:left-[200px] lg:left-[240px]`, matching `RootLayout`'s `md:grid-cols-[200px_1fr] lg:grid-cols-[240px_1fr]` — so `mx-auto` centers it over the content column. On mobile (no sidebar) it's unchanged.

One-line className change. `tsc --noEmit` clean vs the `prerelease` baseline.