### PR TITLE
feat: sort the album picker alphabetically

### DIFF
--- a/src/components/albums/AlbumSelectorDialog.tsx
+++ b/src/components/albums/AlbumSelectorDialog.tsx
@@ -53,7 +53,7 @@ export default function AlbumSelectorDialog({ onSelected, onCreated, onSubmit, d
 
   const fetchData = () => {
     setLoading(true);
-    return listAlbums()
+    return listAlbums({ sortBy: "albumName", sortOrder: "asc" })
       .then(setAlbums)
       .catch(setErrorMessage)
       .finally(() => setLoading(false));


### PR DESCRIPTION
The "add to album" selector dialog (`AlbumSelectorDialog`) lists albums in the list endpoint's default order (`lastPhotoDate` desc), which makes finding an album by name a scan. The endpoint already handles `sortBy=albumName` (localeCompare), so the dialog just asks for `{ sortBy: "albumName", sortOrder: "asc" }`.

One-line change, no API change. `tsc --noEmit` clean vs the `prerelease` baseline.