### PR TITLE
feat(workflows): ALL/ANY matching, Album condition, node delete, geo inside/outside

### DIFF
--- a/src/components/workflows/config/ConditionEditor.tsx
+++ b/src/components/workflows/config/ConditionEditor.tsx
@@ -3,10 +3,12 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
-import { ICondition, ConditionType } from "@/types/workflow";
+import { ICondition, ConditionType, IConditionMatch } from "@/types/workflow";
 import { Plus, X, Check, Tag } from "lucide-react";
 import { listPeople } from "@/handlers/api/people.handler";
 import { listTags, ITag } from "@/handlers/api/tag.handler";
+import { listAlbums } from "@/handlers/api/album.handler";
+import { IAlbum } from "@/types/album";
 import { IPerson } from "@/types/person";
 import { PERSON_THUBNAIL_PATH } from "@/config/routes";
 import { useEffect, useState } from "react";
@@ -37,11 +39,67 @@ const conditionTypeLabels: Record<ConditionType, string> = {
   file_extension: "File Extension",
   face_count: "Face Count",
   time_of_day: "Time of Day",
+  album: "Album",
   not_in_album: "Not in Any Album",
   not_in_specific_album: "Not in Specific Album",
 };
 
-const conditionTypes = Object.keys(conditionTypeLabels) as ConditionType[];
+// Superseded by the "Album" condition, which covers both directions and picks
+// the album from a list instead of asking for a raw id. Still evaluated so
+// workflows saved before it existed keep working — it's just no longer offered
+// for new conditions (see conditionTypesFor).
+const LEGACY_CONDITION_TYPES: ConditionType[] = ["not_in_specific_album"];
+
+const conditionTypes = (Object.keys(conditionTypeLabels) as ConditionType[])
+  .filter((t) => !LEGACY_CONDITION_TYPES.includes(t))
+  .sort((a, b) => conditionTypeLabels[a].localeCompare(conditionTypeLabels[b]));
+
+/** The dropdown list, plus the current value when it's a legacy type — without
+ *  this the Select would render blank for an existing legacy condition. */
+const conditionTypesFor = (current: ConditionType): ConditionType[] =>
+  LEGACY_CONDITION_TYPES.includes(current) ? [...conditionTypes, current] : conditionTypes;
+
+/** Single-album chooser — albums are listed by name rather than asking the
+ *  user to paste an album id (which is what the legacy condition did). The
+ *  name is stored alongside the id so the node summary can read back
+ *  "Album in: Holidays" without re-fetching, same as the person/tag pickers. */
+function AlbumSelect({
+  value,
+  onChange,
+}: {
+  value?: string;
+  onChange: (albumId: string, albumName: string) => void;
+}) {
+  const [albums, setAlbums] = useState<IAlbum[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    listAlbums()
+      .then((res) => setAlbums(res || []))
+      .catch(() => setAlbums([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <Select
+      value={value || ""}
+      onValueChange={(id) => onChange(id, albums.find((a) => a.id === id)?.albumName || "")}
+    >
+      <SelectTrigger className="h-7 text-xs">
+        <SelectValue placeholder={loading ? "Loading albums…" : "Choose an album…"} />
+      </SelectTrigger>
+      <SelectContent>
+        {albums.map((a) => (
+          <SelectItem key={a.id} value={a.id} className="text-xs">
+            {a.albumName}
+            {typeof a.assetCount === "number" ? ` (${a.assetCount})` : ""}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
 
 interface PersonPickerProps {
   selectedIds: string[];
@@ -224,6 +282,10 @@ function TagPicker({ selectedIds, onChange }: TagPickerProps) {
 interface ConditionEditorProps {
   conditions: ICondition[];
   onChange: (conditions: ICondition[]) => void;
+  /** ALL (AND, the default) or ANY (OR). Omit onMatchChange to keep the
+   *  control hidden and the behavior pinned to ALL. */
+  match?: IConditionMatch;
+  onMatchChange?: (match: IConditionMatch) => void;
 }
 
 function ConditionFields({ condition, onChange }: { condition: ICondition; onChange: (c: ICondition) => void }) {
@@ -421,6 +483,13 @@ function ConditionFields({ condition, onChange }: { condition: ICondition; onCha
     case "geo_radius":
       return (
         <div className="space-y-1">
+          <Select value={condition.match || "inside"} onValueChange={(v) => onChange({ ...condition, match: v })}>
+            <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="inside">Inside radius</SelectItem>
+              <SelectItem value="outside">Outside radius</SelectItem>
+            </SelectContent>
+          </Select>
           <div className="flex gap-2">
             <Input className="h-7 text-xs" type="number" step="any" placeholder="Latitude" value={condition.lat ?? ""} onChange={(e) => onChange({ ...condition, lat: parseFloat(e.target.value) || 0 })} />
             <Input className="h-7 text-xs" type="number" step="any" placeholder="Longitude" value={condition.lng ?? ""} onChange={(e) => onChange({ ...condition, lng: parseFloat(e.target.value) || 0 })} />
@@ -429,6 +498,22 @@ function ConditionFields({ condition, onChange }: { condition: ICondition; onCha
             <Input className="h-7 text-xs w-20" type="number" min={1} placeholder="Radius" value={condition.radiusKm ?? ""} onChange={(e) => onChange({ ...condition, radiusKm: parseFloat(e.target.value) || 0 })} />
             <span className="text-xs text-muted-foreground">km</span>
           </div>
+          <p className="text-[10px] text-muted-foreground">
+            True distance from the point. Photos without GPS match neither direction.
+          </p>
+        </div>
+      );
+    case "album":
+      return (
+        <div className="space-y-1">
+          <Select value={condition.match || "in"} onValueChange={(v) => onChange({ ...condition, match: v })}>
+            <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="in">Is in album</SelectItem>
+              <SelectItem value="not_in">Is not in album</SelectItem>
+            </SelectContent>
+          </Select>
+          <AlbumSelect value={condition.albumId} onChange={(albumId, albumName) => onChange({ ...condition, albumId, albumName })} />
         </div>
       );
     case "day_of_week":
@@ -457,13 +542,13 @@ function ConditionFields({ condition, onChange }: { condition: ICondition; onCha
     case "person_unnamed":
       return null;
     case "not_in_specific_album":
-      return <Input className="h-7 text-xs" placeholder="Album ID" value={condition.albumId || ""} onChange={(e) => onChange({ ...condition, albumId: e.target.value })} />;
+      return <AlbumSelect value={condition.albumId} onChange={(albumId, albumName) => onChange({ ...condition, albumId, albumName })} />;
     default:
       return null;
   }
 }
 
-export default function ConditionEditor({ conditions, onChange }: ConditionEditorProps) {
+export default function ConditionEditor({ conditions, onChange, match = "all", onMatchChange }: ConditionEditorProps) {
   const addCondition = () => {
     onChange([...conditions, { type: "city" }]);
   };
@@ -486,13 +571,26 @@ export default function ConditionEditor({ conditions, onChange }: ConditionEdito
 
   return (
     <div className="space-y-2">
+      {conditions.length > 1 && onMatchChange && (
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">Match</span>
+          <Select value={match} onValueChange={(v) => onMatchChange(v as IConditionMatch)}>
+            <SelectTrigger className="h-6 w-[68px] text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all" className="text-xs">ALL</SelectItem>
+              <SelectItem value="any" className="text-xs">ANY</SelectItem>
+            </SelectContent>
+          </Select>
+          <span className="text-xs text-muted-foreground">of these</span>
+        </div>
+      )}
       {conditions.map((condition, i) => (
         <div key={i} className="p-2 border rounded space-y-2 bg-muted/30">
           <div className="flex items-center gap-1">
             <Select value={condition.type} onValueChange={(v) => changeType(i, v as ConditionType)}>
               <SelectTrigger className="h-7 text-xs flex-1"><SelectValue /></SelectTrigger>
               <SelectContent>
-                {conditionTypes.map((t) => (
+                {conditionTypesFor(condition.type).map((t) => (
                   <SelectItem key={t} value={t}>{conditionTypeLabels[t]}</SelectItem>
                 ))}
               </SelectContent>
@@ -504,7 +602,9 @@ export default function ConditionEditor({ conditions, onChange }: ConditionEdito
           <ConditionFields condition={condition} onChange={(c) => updateCondition(i, c)} />
           {i < conditions.length - 1 && (
             <div className="text-center">
-              <span className="text-[10px] font-medium text-muted-foreground bg-muted px-2 py-0.5 rounded">AND</span>
+              <span className="text-[10px] font-medium text-muted-foreground bg-muted px-2 py-0.5 rounded">
+                {match === "any" ? "OR" : "AND"}
+              </span>
             </div>
           )}
         </div>

--- a/src/components/workflows/config/IfConfig.tsx
+++ b/src/components/workflows/config/IfConfig.tsx
@@ -1,22 +1,29 @@
-import { ICondition } from "@/types/workflow";
+import { ICondition, IConditionMatch } from "@/types/workflow";
 import ConditionEditor from "./ConditionEditor";
 import { Label } from "@/components/ui/label";
 
 interface IfConfigProps {
-  config: { conditions?: ICondition[] };
+  config: { conditions?: ICondition[]; match?: IConditionMatch };
   onChange: (config: any) => void;
 }
 
 export default function IfConfig({ config, onChange }: IfConfigProps) {
+  const match = config.match ?? "all";
   return (
     <div className="space-y-3">
       <div>
-        <Label className="text-xs">Conditions (AND)</Label>
-        <p className="text-[10px] text-muted-foreground mb-2">All conditions must match for the TRUE branch.</p>
+        <Label className="text-xs">Conditions</Label>
+        <p className="text-[10px] text-muted-foreground mb-2">
+          {match === "any"
+            ? "Assets matching ANY condition take the TRUE branch."
+            : "Assets matching ALL conditions take the TRUE branch."}
+        </p>
       </div>
       <ConditionEditor
         conditions={config.conditions || []}
         onChange={(conditions) => onChange({ ...config, conditions })}
+        match={match}
+        onMatchChange={(m) => onChange({ ...config, match: m })}
       />
     </div>
   );

--- a/src/components/workflows/config/SwitchConfig.tsx
+++ b/src/components/workflows/config/SwitchConfig.tsx
@@ -1,4 +1,4 @@
-import { ICondition } from "@/types/workflow";
+import { ICondition, IConditionMatch } from "@/types/workflow";
 import ConditionEditor from "./ConditionEditor";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,6 +9,7 @@ interface SwitchCase {
   label: string;
   conditions: ICondition[];
   handle: string;
+  match?: IConditionMatch;
 }
 
 interface SwitchConfigProps {
@@ -59,6 +60,8 @@ export default function SwitchConfig({ config, onChange }: SwitchConfigProps) {
           <ConditionEditor
             conditions={c.conditions}
             onChange={(conditions) => updateCase(i, { conditions })}
+            match={c.match ?? "all"}
+            onMatchChange={(m) => updateCase(i, { match: m })}
           />
         </div>
       ))}

--- a/src/components/workflows/nodes/conditionSummary.ts
+++ b/src/components/workflows/nodes/conditionSummary.ts
@@ -25,6 +25,7 @@ const conditionTypeLabels: Record<ConditionType, string> = {
   file_extension: "Extension",
   face_count: "Faces",
   time_of_day: "Time of Day",
+  album: "Album",
   not_in_album: "Not in Any Album",
   not_in_specific_album: "Not in Specific Album",
 };
@@ -68,7 +69,8 @@ export function formatConditionSummary(c: ICondition): string {
     }
     case "geo_radius": {
       if (c.lat != null && c.lng != null) {
-        return `${label}: ${c.lat}, ${c.lng} (${c.radiusKm || "?"}km)`;
+        const dir = c.match === "outside" ? "outside" : "inside";
+        return `${label} ${dir}: ${c.lat}, ${c.lng} (${c.radiusKm || "?"}km)`;
       }
       return label;
     }
@@ -149,8 +151,15 @@ export function formatConditionSummary(c: ICondition): string {
     }
     case "not_in_album":
       return label;
-    case "not_in_specific_album":
-      return c.albumId ? `${label}: ${c.albumId}` : label;
+    case "album": {
+      const dir = c.match === "not_in" ? "not in" : "in";
+      const name = c.albumName || c.albumId;
+      return name ? `${label} ${dir}: ${name}` : `${label}: (none selected)`;
+    }
+    case "not_in_specific_album": {
+      const name = c.albumName || c.albumId;
+      return name ? `${label}: ${name}` : label;
+    }
     default:
       return label;
   }

--- a/src/lib/workflow/conditionBuilder.ts
+++ b/src/lib/workflow/conditionBuilder.ts
@@ -1,23 +1,34 @@
-import { SQL, and, eq, ne, gte, lte, isNull, sql } from "drizzle-orm";
+import { SQL, and, or, eq, ne, gte, lte, isNull, sql } from "drizzle-orm";
 import { assets } from "@/schema/assets.schema";
 import { exif } from "@/schema";
-import { ICondition } from "@/types/workflow";
+import { ICondition, IConditionMatch } from "@/types/workflow";
 import { subDays } from "date-fns";
 
-export function buildConditions(conditions: ICondition[], ownerId: string): SQL[] {
-  const clauses: SQL[] = [
+export function buildConditions(
+  conditions: ICondition[],
+  ownerId: string,
+  match: IConditionMatch = "all",
+): SQL[] {
+  // These four are NON-NEGOTIABLE and always ANDed. They must never be folded
+  // into the OR group below — under "match any" that would make a single
+  // matching user condition pull in other owners' / trashed / archived assets.
+  const base: SQL[] = [
     eq(assets.ownerId, ownerId),
     eq(assets.visibility, "timeline"),
     eq(assets.status, "active"),
     isNull(assets.deletedAt),
   ];
 
+  const userClauses: SQL[] = [];
   for (const c of conditions) {
     const clause = buildSingleCondition(c);
-    if (clause) clauses.push(clause);
+    if (clause) userClauses.push(clause);
   }
 
-  return clauses;
+  if (userClauses.length === 0) return base;
+  // "any" => OR the user's conditions together as ONE clause, still ANDed
+  // against the base scoping. "all" (default) keeps the historical behavior.
+  return match === "any" ? [...base, or(...userClauses)!] : [...base, ...userClauses];
 }
 
 function buildSingleCondition(c: ICondition): SQL | undefined {
@@ -228,22 +239,69 @@ function buildSingleCondition(c: ICondition): SQL | undefined {
     case "not_in_album":
       return sql`NOT EXISTS (SELECT 1 FROM "album_asset" aa WHERE aa."assetId" = ${assets.id})`;
 
+    // Kept for workflows saved before the "album" condition existed; the new
+    // "album" type below covers both directions with an album picker.
     case "not_in_specific_album":
       return sql`NOT EXISTS (SELECT 1 FROM "album_asset" aa WHERE aa."assetId" = ${assets.id} AND aa."albumId" = ${c.albumId})`;
 
-    case "geo_radius":
-      if (c.lat !== undefined && c.lng !== undefined && c.radiusKm) {
-        // Haversine approximation: 1 degree ≈ 111km
-        const latDelta = c.radiusKm / 111;
-        const lngDelta = c.radiusKm / (111 * Math.cos((c.lat * Math.PI) / 180));
-        return and(
-          gte(exif.latitude, c.lat - latDelta),
-          lte(exif.latitude, c.lat + latDelta),
-          gte(exif.longitude, c.lng - lngDelta),
-          lte(exif.longitude, c.lng + lngDelta),
-        )!;
+    case "album": {
+      if (!c.albumId) return undefined;
+      return c.match === "not_in"
+        ? sql`NOT EXISTS (SELECT 1 FROM "album_asset" aa WHERE aa."assetId" = ${assets.id} AND aa."albumId" = ${c.albumId})`
+        : sql`EXISTS (SELECT 1 FROM "album_asset" aa WHERE aa."assetId" = ${assets.id} AND aa."albumId" = ${c.albumId})`;
+    }
+
+    case "geo_radius": {
+      const lat = Number(c.lat);
+      const lng = Number(c.lng);
+      const r = Number(c.radiusKm);
+      if (![lat, lng, r].every(Number.isFinite) || r <= 0) return undefined;
+
+      // A photo with no coordinates is neither inside nor outside, so both
+      // directions require GPS rather than sweeping every un-located photo
+      // into "outside".
+      const hasGps = and(
+        sql`${exif.latitude} IS NOT NULL`,
+        sql`${exif.longitude} IS NOT NULL`,
+      )!;
+
+      // Exact great-circle (haversine) distance in km. The previous version
+      // used only the bounding box below, which is a square — its corners sit
+      // up to ~1.41x the requested radius away.
+      const distanceKm = sql`(2 * 6371 * asin(sqrt(
+        power(sin(radians(${exif.latitude} - ${lat}) / 2), 2) +
+        cos(radians(${lat})) * cos(radians(${exif.latitude})) *
+        power(sin(radians(${exif.longitude} - ${lng}) / 2), 2)
+      )))`;
+
+      if (c.match === "outside") {
+        // No bounding box here: it would wrongly exclude far-away photos.
+        return and(hasGps, sql`${distanceKm} > ${r}`)!;
       }
-      return undefined;
+
+      // Inside: cheap, index-friendly bounding box narrows the set first, then
+      // the exact distance trims the corners. Skipped near the poles or the
+      // antimeridian, where a naive box wraps and would drop real matches.
+      const latDelta = r / 111.045;
+      const cosLat = Math.cos((lat * Math.PI) / 180);
+      const lngDelta = Math.abs(cosLat) < 1e-6 ? 180 : r / (111.045 * Math.abs(cosLat));
+      const boxSafe =
+        lngDelta < 180 &&
+        lng - lngDelta >= -180 && lng + lngDelta <= 180 &&
+        lat - latDelta >= -90 && lat + latDelta <= 90;
+
+      const parts: SQL[] = [hasGps];
+      if (boxSafe) {
+        parts.push(
+          gte(exif.latitude, lat - latDelta),
+          lte(exif.latitude, lat + latDelta),
+          gte(exif.longitude, lng - lngDelta),
+          lte(exif.longitude, lng + lngDelta),
+        );
+      }
+      parts.push(sql`${distanceKm} <= ${r}`);
+      return and(...parts)!;
+    }
 
     default:
       return undefined;

--- a/src/lib/workflow/engine.ts
+++ b/src/lib/workflow/engine.ts
@@ -296,9 +296,9 @@ export async function executeWorkflow(
         if (node.subType === "if") {
           // Query assets matching conditions, scoped to incoming set
           const conditions = config.conditions || [];
-          log(runId, `IF: ${conditions.length} conditions: ${conditions.map((c: any) => c.type).join(", ")}`);
+          log(runId, `IF: match ${config.match ?? "all"} of ${conditions.length} conditions: ${conditions.map((c: any) => c.type).join(", ")}`);
 
-          const whereClauses = buildConditions(conditions, user.id);
+          const whereClauses = buildConditions(conditions, user.id, config.match ?? "all");
 
           // Scoped to incoming assets (chunked) when available
           const matchedIds = await queryConditionMatches(whereClauses, assetIds);
@@ -339,9 +339,9 @@ export async function executeWorkflow(
 
           for (let ci = 0; ci < cases.length; ci++) {
             const c = cases[ci];
-            log(runId, `  Case "${c.label || ci}": ${(c.conditions || []).length} conditions, checking against ${remaining?.length ?? "all"} assets`);
+            log(runId, `  Case "${c.label || ci}": match ${c.match ?? "all"} of ${(c.conditions || []).length} conditions, checking against ${remaining?.length ?? "all"} assets`);
 
-            const whereClauses = buildConditions(c.conditions || [], user.id);
+            const whereClauses = buildConditions(c.conditions || [], user.id, c.match ?? "all");
 
             // Scoped to remaining assets (chunked) when available
             const matchedIds = await queryConditionMatches(whereClauses, remaining);

--- a/src/pages/workflows/[id].tsx
+++ b/src/pages/workflows/[id].tsx
@@ -31,7 +31,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Badge } from "@/components/ui/badge";
 import { ASSET_THUMBNAIL_PATH } from "@/config/routes";
 import { IWorkflowRun } from "@/types/workflow";
-import { ArrowLeft, Play, Save, Clock, Webhook, History, ChevronUp, ChevronDown, Bug } from "lucide-react";
+import { ArrowLeft, Play, Save, Clock, Webhook, History, ChevronUp, ChevronDown, Bug, Trash2 } from "lucide-react";
 import Head from "next/head";
 import { format } from "date-fns";
 import Link from "next/link";
@@ -346,6 +346,17 @@ function WorkflowEditorInner() {
     setSelectedNode((prev) => prev ? { ...prev, data: { ...prev.data, config } } : null);
   }, [selectedNode, setNodes]);
 
+  // Selecting a node and pressing Delete/Backspace already worked, but there
+  // was no visible way to do it — which left orphaned nodes stranded on the
+  // canvas. Drops the node and any edges touching it; takes effect on Save.
+  const deleteSelectedNode = useCallback(() => {
+    if (!selectedNode) return;
+    const id = selectedNode.id;
+    setNodes((nds) => nds.filter((n) => n.id !== id));
+    setEdges((eds) => eds.filter((e) => e.source !== id && e.target !== id));
+    setSelectedNode(null);
+  }, [selectedNode, setNodes, setEdges]);
+
   const handleSave = async () => {
     if (!id) return;
     setSaving(true);
@@ -397,7 +408,18 @@ function WorkflowEditorInner() {
 
     return (
       <div className="p-4 space-y-4 overflow-y-auto">
-        <h3 className="text-sm font-semibold">{typeLabel}: {subType}</h3>
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="text-sm font-semibold">{typeLabel}: {subType}</h3>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+            title="Delete this node (or select it and press Delete)"
+            onClick={deleteSelectedNode}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
         {nodeType === "trigger" && (
           <div className="space-y-3">
             <p className="text-xs text-muted-foreground">

--- a/src/types/workflow.d.ts
+++ b/src/types/workflow.d.ts
@@ -57,6 +57,7 @@ export type ConditionType =
   | "rating" | "is_favorited" | "resolution"
   | "file_size" | "filename" | "file_extension"
   | "face_count" | "time_of_day"
+  | "album"
   | "not_in_album" | "not_in_specific_album";
 
 export interface ICondition {
@@ -64,12 +65,16 @@ export interface ICondition {
   [key: string]: any;
 }
 
+/** How a node's condition list is combined. "all" = AND (default, and the
+ *  historical behavior for nodes saved before this existed), "any" = OR. */
+export type IConditionMatch = "all" | "any";
+
 export interface IManualTriggerData {}
 export interface IScheduleTriggerData { cron: string; }
 export interface IWebhookTriggerData { token: string; }
 
-export interface IIfNodeData { conditions: ICondition[]; }
-export interface ISwitchCase { label: string; conditions: ICondition[]; handle: string; }
+export interface IIfNodeData { conditions: ICondition[]; match?: IConditionMatch; }
+export interface ISwitchCase { label: string; conditions: ICondition[]; handle: string; match?: IConditionMatch; }
 export interface ISwitchNodeData { cases: ISwitchCase[]; }
 
 export interface ICreateAlbumActionData { nameTemplate: string; }


### PR DESCRIPTION
Four enhancements to workflow **If** / **Switch** conditions.

### ALL / ANY matching
Conditions can be combined with **ALL** (AND — the unchanged default) or **ANY** (OR), chosen per If node and per Switch case, with the joiner between conditions reading "AND"/"OR" so the rule is legible.

The owner / visibility / status / `deletedAt` scoping clauses stay ANDed in **every** case — folding those into the OR group would let a single matching user-condition pull in other users' or trashed assets.

### Album condition
A new **Album** condition — in / not-in with an album picker. It supersedes **"Not in Specific Album"** (which asked for a raw album id). The old type is still *evaluated* so existing workflows keep working, but it's no longer offered when adding a new condition.

### Geo Radius: inside / outside, true distance
Geo Radius gains **inside / outside**, and now measures true great-circle distance. The previous implementation was a lat/lng **bounding box** despite the "haversine" comment, so its corners reached ~1.41× the requested radius. Inside keeps the box as an index-friendly pre-filter and trims by exact distance; outside can't (the box would exclude far-away photos). Photos without GPS match neither direction.

> **Relationship to #316:** this **supersedes #316** — the true-distance fix there is a subset of the geo work here (this adds the inside/outside direction on top of it). Merge this and close #316, or merge #316 first and I'll rebase. They touch the same `geo_radius` case, so they shouldn't both land.

### Node delete
Nodes can be deleted from the canvas via a button in the config panel. Select-then-Delete already worked but had no visible affordance, so orphaned nodes were stranded. Removing a node also removes any edges touching it.

---

**Deferred:** the fork also has a Geo-Radius **point picker** (place search / paste a coordinate pair) that reuses `LocationSearchBox` + `coordinates` from the GPS Manager module (#308). It's held back until #308 lands, since it depends on those files. This PR keeps the plain lat/lng inputs.

**Not included here:** the Manage People "hide hidden by default" change that shared the original fork commit is submitted separately in #319.

`tsc --noEmit` clean vs the `prerelease` baseline.
