### PR TITLE
Update healthcheck URL in docker-compose file

### DIFF
--- a/docker-compose-all-immich.yml
+++ b/docker-compose-all-immich.yml
@@ -81,7 +81,7 @@ services:
     env_file:
       - .env
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://immich_power_tools:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Resolves issue #153 `Connecting to localhost:3000 (127.0.0.1:3000) wget: can't connect to remote host (127.0.0.1): Connection refused` by replacing "localhost" with the container's hostname.